### PR TITLE
Docs: add Meshery MCP Server overview and scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@
         <br />
     </div>
 
+## Meshery MCP Server extension
+
+The Meshery MCP Server extension provides a dedicated Model Context Protocol (MCP) server that streamlines and accelerates the creation and management of Meshery designs. As an official Meshery Extension, it is owned end-to-end by its maintainers—covering architecture and design, implementation, tests, documentation, and publication to both the MCP and Skills marketplaces.
+
+The initial scope for the MCP Server, in priority order, includes:
+
+1. Creation of Meshery designs.
+2. Retrieval of designs in the user's requested file format (for example, JSON or YAML representations of designs).
+3. Snapshotting of Meshery designs.
+4. Design deployment dry-run results.
+5. Definition, invocation, and results of performance tests.
+
+Contributors who are capable of and available to carry this work through independently—from 0% to 100%—may become the project's official maintainer(s).
+
 Meshery's [high project velocity](https://meshery.io/blog/sixth-highest-velocity-cncf-project) necessitates a revision in its governance and organizational structure to align with the scale of its growing complexity and community contributions. To best serve its expansive ecosystem, Meshery maintainers have opted to partition its numerous GitHub repositories into two distinct organizations: [github.com/meshery](https://github.com/meshery) for the core platform and [meshery-extensions](https://github.com/meshery-extensions) for [extensions](https://meshery.io/extensions) and [integrations](https://meshery.io/integrations).
 
 [Meshery Extensions](https://meshery.io/extension) are plugins or add-ons that enhance the functionality of the Meshery platform beyond its core capabilities. Meshery supports different [types of extensions](https://docs.meshery.io/extensions/)):


### PR DESCRIPTION
This PR updates the README with a dedicated “Meshery MCP Server extension” section.

- Clearly describes the MCP Server extension and its role as a dedicated MCP server for Meshery designs.
- Documents the initial scope in priority order (design creation, export formats, snapshots, dry-run results, performance tests) as outlined in the maintainer announcement.
- Keeps the existing meshery-extensions overview, repository list, and community/contributing guidance intact.

**Notes for Reviewers**

- This PR fixes # (N/A – documentation improvement; no linked issue yet)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation introducing the Meshery MCP Server extension.
  * Described supported capabilities, including design creation and retrieval, snapshotting, deployment dry runs, and performance testing.
  * Documented the path for independent contributors to become official maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->