### PR TITLE
docs: add Meshery MCP Server documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,95 @@
-<div>
-    <!-- Top section -->
-    <div>
-        <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-github.png" usemap="#workmap"  />
-    </div>
-    <!-- Overview section -->
-    <div align="center">
-        <h3>Meshery is an extensible, self-service engineering plaform for the collaborative management of cloud and cloud native infrastructure.</h3>
-        <h3 align="center"><a href="https://meshery.io/extensions">Browse all extensions</a></h3>
-        <h5 align="center">
-            <a href="https://meshery.io#getting-started">Installation</a> |
-            <a href="https://docs.meshery.io">Documentation</a> |
-            <a href="https://discuss.meshery.io">Forum</a> |
-            <a href="https://play.meshery.io">Playground</a> |
-            <a href="https://meshery.io/catalog">Catalog</a>
-        </h5>
-        <br />
-    </div>
+# Meshery MCP Server
 
-Meshery's [high project velocity](https://meshery.io/blog/sixth-highest-velocity-cncf-project) necessitates a revision in its governance and organizational structure to align with the scale of its growing complexity and community contributions. To best serve its expansive ecosystem, Meshery maintainers have opted to partition its numerous GitHub repositories into two distinct organizations: [github.com/meshery](https://github.com/meshery) for the core platform and [meshery-extensions](https://github.com/meshery-extensions) for [extensions](https://meshery.io/extensions) and [integrations](https://meshery.io/integrations).
-
-[Meshery Extensions](https://meshery.io/extension) are plugins or add-ons that enhance the functionality of the Meshery platform beyond its core capabilities. Meshery supports different [types of extensions](https://docs.meshery.io/extensions/)):
-
-- [Academies](https://docs.meshery.io/extensions/academies): Academy extensions enable Meshery as an integrated learning platform.
-- [Adapters](https://docs.meshery.io/concepts/architecture/adapters): Adapters allow Meshery to interface with the different cloud native infrastructure.\
-- [Build-time](https://docs.meshery.io/reference/extensibility/build-time/): enable integrators to inject custom configurations, data, provider extensions, and other resources directly into the Meshery container image at build-time.
-- CLI: Helm and _kubectl_ plugins that let you create Kanvas snapshots from Helm charts, Kubernetes manifests, and the current state of your Kubernetes cluster, then upload them to Meshery.
-    - [Kubectl CLI Plugin](https://docs.meshery.io/extensions/kubectl-meshsync-snapshot/)
-    - [Helm CLI Plugin](https://docs.meshery.io/extensions/helm-kanvas-snapshot/)
-- [Load Generators](https://docs.meshery.io/extensibility/load-generators): for performance characterization and benchmarking.
-- [Models](https://docs.meshery.io/extensions/models/): component-based (semantically and non-semantically meaningful) support for a broad variety of platforms, tools, and technologies.
-- [Providers](https://docs.meshery.io/extensibility/providers): for connecting to different cloud providers and infrastructure platforms.
-- [Schemas](https://docs.meshery.io/reference/extensibility/schemas/) - Meshery schemas are conscientiously extensible via `x-*` vendor extensions.
-- [UI Plugins](https://docs.meshery.io/extensibility/ui): Meshery UI has a number of extension points that allow users to customize their experience with third-party plugins.
-
-This organization is managed by Meshery core and extension maintainers. Repositories in this organization need to be sponsored and created by one or more of the core maintainers. Read more about the [rationale for the project's multi-organization approach and it's governance structure](https://meshery.io/blog/2025/meshery-ecosystem-expansion).
-
-<!-- Blog Post and Explanation section -->
-<!-- Video Section -->
-<h3 align="center">See Meshery and it's plugins in-action</h3>
-    <img src="https://raw.githubusercontent.com/meshery/.github/master/profile/assets/img/meshery-dashboard-hero-image.png"  />
-<!--     <div align="center"><i>Example extension. See other <a href="https://meshery.io/extensions">Meshery Extensions</a>.<i></div>
-    <br /> -->
-    <!-- Repositories section -->
-
-# MCP Server
-
-<a href="https://github.com/meshery/meshery/blob/master/GOVERNANCE.md#extensions-githubcommeshery-extensions"><img src="https://img.shields.io/badge/support-community-00B39F?style=flat-square&logo=meshery&logoColor=white"  alt="Level of support for this repo"></a>
-
-<!-- Contributing and Guidelines -->
-<div>
-    <h2>Community and Contributing</h2>
-    <p>Please do! Code and non-code contributions are welcome. This project is community-built and fosters collaboration. Contributors are expected to adhere to the <a href="https://github.com/cncf/foundation/blob/main/code-of-conduct.md"> CNCF Code of Conduct</a>.
-    </p>
-    <p>Jump into our <a href="https://slack.meshery.io">Slack</a>! Submit your <a href="https://meshery.io/newcomers">community member form</a> access to additional resources. Don't forget to join the <a href="https://meshery.io/calendar">Newcomers meeting</a> held every Thursday!
-    </p>
-    <img src="https://raw.githubusercontent.com/meshery/meshery/refs/heads/master/.github/assets/images/readme/community.png"
-        style="margin:10px;" width="180px" alt="Community" align="right" />
-    <ul>
-        ✔️ <b>Star</b> ⭐ the main <a href="https://github.com/meshery/meshery">meshery repo</a><br />
-        ✔️ <b>Join</b> any or all of the weekly meetings on the <a href="https://meet.meshery.io">community
-                calendar</a><br />
-        ✔️ <b>Watch</b> <a
-                href="https://www.youtube.com/@mesheryio?sub_confirmation=1">community meeting
-                recordings</a><br />
-        <p>✔️ <b>Access</b> resources by completing a <a href="https://meshery.io/newcomers"> community member form
-            </a><br />
-        ✔️ <b>Discuss</b> in a Meshery <a href="https://discuss.meshery.io">Community forum</a><br />
-        ✔️ Not sure where to start? <b>Grab</b> an open issue with the <a
-                href="https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+(org%3Ameshery+OR+org%3Aservice-mesh-performance+OR+org%3Aservice-mesh-patterns+OR+org%3Ameshery-extensions)+label%3A%22help+wanted%22">help-wanted
-                label</a><br />
-    </ul>
+<div align="center">
+    <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-github.png" alt="Meshery Extensions" />
 </div>
-<!-- Footer Section -->
-<img src="https://raw.githubusercontent.com/meshery/.github/master/profile/assets/img/footer.png" align="center" />
+
+Meshery MCP Server is an official Meshery extension that provides an interface between MCP-compatible AI clients and Meshery.
+
+The project aims to make Meshery capabilities accessible through the Model Context Protocol (MCP), enabling AI assistants to interact with Meshery and assist with cloud-native design workflows.
+
+## Overview
+
+[Meshery](https://meshery.io/) is a cloud-native engineering platform for collaboratively designing and operating cloud and cloud-native infrastructure.
+
+The Meshery MCP Server extends Meshery with an MCP interface. MCP-compatible clients can communicate with the server using standardized MCP interactions.
+
+This project is being developed in Go and is intended to support MCP-compatible AI clients.
+
+## Architecture
+
+```text
+┌─────────────────────────────┐
+│         MCP Client          │
+│ Claude / Cursor / VS Code   │
+│ Cline / other AI clients    │
+└──────────────┬──────────────┘
+               │
+               │ MCP
+               ▼
+┌─────────────────────────────┐
+│      Meshery MCP Server     │
+└──────────────┬──────────────┘
+               │
+               │ Meshery API
+               ▼
+┌─────────────────────────────┐
+│           Meshery           │
+└──────────────┬──────────────┘
+               │
+               ▼
+┌─────────────────────────────┐
+│ Kubernetes / Cloud-Native   │
+│ Infrastructure              │
+└─────────────────────────────┘
+```
+
+## Project Status
+
+Meshery MCP Server is currently under active development.
+
+The project is being developed to provide:
+
+- MCP server functionality for Meshery.
+- Access to Meshery APIs through MCP.
+- MCP tools for Meshery capabilities.
+- MCP resources for Meshery data.
+- MCP prompts for guided workflows.
+- Integration with MCP-compatible AI clients.
+- Documentation and examples for users and contributors.
+
+> **Note:** The server is currently under development. Installation commands, configuration options, tools, and client integration examples will be documented as the corresponding functionality becomes available.
+
+## Documentation
+
+Project-specific documentation will be maintained in this repository as the MCP server implementation develops.
+
+For Meshery documentation, see:
+
+- [Meshery Documentation](https://docs.meshery.io/)
+- [Meshery Quick Start](https://docs.meshery.io/installation/quick-start/)
+- [Meshery Extensions](https://docs.meshery.io/extensions/)
+- [Meshery REST API Reference](https://docs.meshery.io/reference/rest-apis/)
+
+## Meshery Resources
+
+- [Meshery](https://meshery.io/)
+- [Meshery GitHub Repository](https://github.com/meshery/meshery)
+
+## Community and Contributing
+
+Contributions to the Meshery MCP Server are welcome.
+
+Before contributing, please review:
+
+- [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+
+Join the Meshery community:
+
+- [Community Slack](https://slack.meshery.io/)
+- [Community Forum](https://discuss.meshery.io/)
+- [Community Calendar](https://meshery.io/calendar)
+
+## License
+
+Meshery MCP Server is licensed under the Apache License 2.0.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Meshery MCP Server
 
-<div align="center">
-    <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-github.png" alt="Meshery Extensions" />
+<div>
+    <img src="https://raw.githubusercontent.com/meshery-extensions/.github/master/profile/assets/img/meshery-extensions-github.png" alt="Meshery MCP Server" />
 </div>
 
 Meshery MCP Server is an official Meshery extension that provides an interface between MCP-compatible AI clients and Meshery.
@@ -10,11 +10,11 @@ The project aims to make Meshery capabilities accessible through the Model Conte
 
 ## Overview
 
-[Meshery](https://meshery.io/) is a cloud-native engineering platform for collaboratively designing and operating cloud and cloud-native infrastructure.
+[Meshery](https://meshery.io/) is a cloud-native management platform for designing and managing Kubernetes and cloud-native infrastructure.
 
 The Meshery MCP Server extends Meshery with an MCP interface. MCP-compatible clients can communicate with the server using standardized MCP interactions.
 
-This project is being developed in Go and is intended to support MCP-compatible AI clients.
+This project is being developed in Go and is intended to support AI clients such as Claude Desktop, Cursor, VS Code, and other MCP-compatible applications.
 
 ## Architecture
 
@@ -58,23 +58,32 @@ The project is being developed to provide:
 - Integration with MCP-compatible AI clients.
 - Documentation and examples for users and contributors.
 
-> **Note:** The server is currently under development. Installation commands, configuration options, tools, and client integration examples will be documented as the corresponding functionality becomes available.
+> **Note:** The documentation currently available in this repository covers installation, configuration, development, tools, and MCP client integrations. Some advanced MCP capabilities remain under active development and will be documented as they become available.
 
 ## Documentation
 
-Project-specific documentation will be maintained in this repository as the MCP server implementation develops.
+- [Installation](docs/installation.md)
+- [Configuration](docs/configuration.md)
+- [Tools Reference](docs/tools-reference.md)
+- [Development Guide](docs/development.md)
 
-For Meshery documentation, see:
+### AI Client Integrations
 
-- [Meshery Documentation](https://docs.meshery.io/)
-- [Meshery Quick Start](https://docs.meshery.io/installation/quick-start/)
-- [Meshery Extensions](https://docs.meshery.io/extensions/)
-- [Meshery REST API Reference](https://docs.meshery.io/reference/rest-apis/)
+- [Claude Desktop](docs/integrations/claude-desktop.md)
+- [VS Code / GitHub Copilot](docs/integrations/vscode-copilot.md)
+- [Cursor](docs/integrations/cursor.md)
+- [Cline](docs/integrations/cline.md)
+
+### Planned Features
+
+The complete MCP tool, resource, prompt, and transport surface is still under development. Documentation for features that are not yet implemented will be added as the corresponding functionality becomes available.
 
 ## Meshery Resources
 
 - [Meshery](https://meshery.io/)
-- [Meshery GitHub Repository](https://github.com/meshery/meshery)
+- [Meshery Documentation](https://docs.meshery.io/)
+- [Meshery GitHub](https://github.com/meshery/meshery)
+- [Meshery Extensions](https://meshery.io/extensions)
 
 ## Community and Contributing
 
@@ -82,11 +91,13 @@ Contributions to the Meshery MCP Server are welcome.
 
 Before contributing, please review:
 
-- [Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Code of Conduct](CODE_OF_CONDUCT.md)
+- [Security Policy](SECURITY.md)
 
 Join the Meshery community:
 
-- [Community Slack](https://slack.meshery.io/)
+- [Slack](https://slack.meshery.io/)
 - [Community Forum](https://discuss.meshery.io/)
 - [Community Calendar](https://meshery.io/calendar)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,73 @@
+# Configuration
+
+> **Status:** Meshery MCP Server is currently under active development.
+
+This document describes the configuration options planned for Meshery MCP Server. Configuration details should be kept in sync with the server implementation.
+
+## Meshery Server URL
+
+The Meshery server URL identifies the Meshery instance that the MCP server communicates with.
+
+Environment variable:
+
+`MESHERY_SERVER_URL`
+
+Default:
+
+`http://localhost:9081`
+
+Example:
+
+    MESHERY_SERVER_URL=http://localhost:9081
+
+On PowerShell:
+
+    $env:MESHERY_SERVER_URL="http://localhost:9081"
+
+## Meshery API Token
+
+Authentication can be configured with the Meshery provider/API token.
+
+Environment variable:
+
+`MESHERY_API_TOKEN`
+
+Example:
+
+    MESHERY_API_TOKEN=your-token
+
+Do not commit tokens or other credentials to source control.
+
+## Configuration File
+
+A configuration-file based setup is planned for the server.
+
+The supported file path, format, fields, and precedence rules should be documented here once the configuration implementation is finalized.
+
+## Command-Line Configuration
+
+Command-line flags will be documented here when they are implemented.
+
+## Environment Variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `MESHERY_SERVER_URL` | URL of the Meshery server | `http://localhost:9081` |
+| `MESHERY_API_TOKEN` | Meshery provider/API token | Not set |
+
+## Configuration Precedence
+
+The final configuration precedence will be documented when the implementation is finalized.
+
+## Security
+
+- Never commit API tokens to Git.
+- Do not place credentials in public documentation examples.
+- Prefer environment variables or a local configuration file for development credentials.
+- Use appropriate secret-management facilities for production deployments.
+
+## Related Documentation
+
+- [Installation](installation.md)
+- [Tools Reference](tools-reference.md)
+- [Development Guide](development.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,70 +1,225 @@
 # Configuration
 
-> **Status:** Meshery MCP Server is currently under active development.
+Meshery MCP Server supports configuration through a YAML configuration file and environment variables.
 
-This document describes the configuration options planned for Meshery MCP Server. Configuration details should be kept in sync with the server implementation.
+## Configuration File
 
-## Meshery Server URL
+The default configuration file is:
 
-The Meshery server URL identifies the Meshery instance that the MCP server communicates with.
+    ~/.meshery/mcp-config.yaml
 
-Environment variable:
+The configuration file can contain multiple Meshery contexts.
 
-`MESHERY_SERVER_URL`
+### Configuration Format
 
-Default:
+    current-context: dev
 
-`http://localhost:9081`
+    contexts:
+      dev:
+        server: http://localhost:9081
+        token: <your-meshery-api-token>
+        provider: Meshery
+
+      production:
+        server: https://meshery.example.com
+        token: <your-meshery-api-token>
+        provider: Meshery
+
+### Configuration Fields
+
+| Field | Description |
+| --- | --- |
+| `current-context` | Name of the currently active context |
+| `contexts` | Map containing the configured Meshery contexts |
+| `server` | Base URL of the Meshery Server REST API |
+| `token` | API token used for authentication |
+| `provider` | Meshery provider name, such as `Meshery` or `None` |
+
+The active context must exist in the `contexts` map and must contain a valid server URL.
+
+## Custom Configuration File
+
+To use a configuration file at a different location, set:
+
+    MESHERY_CONFIG_PATH
 
 Example:
 
-    MESHERY_SERVER_URL=http://localhost:9081
+    export MESHERY_CONFIG_PATH=/path/to/mcp-config.yaml
+
+On PowerShell:
+
+    $env:MESHERY_CONFIG_PATH="C:\path\to\mcp-config.yaml"
+
+## Environment Variables
+
+Environment variables can be used instead of a configuration file or to override values in the active context.
+
+### MESHERY_SERVER_URL
+
+Specifies the Meshery server URL.
+
+Default:
+
+    http://localhost:9081
+
+Example:
+
+    export MESHERY_SERVER_URL=http://localhost:9081
+
+PowerShell:
+
+    $env:MESHERY_SERVER_URL="http://localhost:9081"
+
+### MESHERY_API_TOKEN
+
+Specifies the Meshery API token used for authentication.
+
+Example:
+
+    export MESHERY_API_TOKEN=<your-meshery-api-token>
+
+PowerShell:
+
+    $env:MESHERY_API_TOKEN="<your-meshery-api-token>"
+
+Do not commit API tokens or other credentials to Git.
+
+### MESHERY_PROVIDER
+
+Specifies the Meshery provider associated with the active context.
+
+Example:
+
+    export MESHERY_PROVIDER=Meshery
+
+PowerShell:
+
+    $env:MESHERY_PROVIDER="Meshery"
+
+### MESHERY_CONTEXT
+
+Specifies which configured context should be active.
+
+Example:
+
+    export MESHERY_CONTEXT=production
+
+PowerShell:
+
+    $env:MESHERY_CONTEXT="production"
+
+If the specified context does not exist, the existing configured context selection is not replaced.
+
+## Configuration Priority
+
+When the configuration is loaded, Meshery MCP Server:
+
+1. Attempts to load the configuration file.
+2. If the configuration file does not exist, creates a configuration from environment variables.
+3. Applies environment variable overrides to the active context.
+
+Environment variables override configuration-file values for the active context.
+
+The following environment variables can override configuration:
+
+- `MESHERY_CONTEXT`
+- `MESHERY_SERVER_URL`
+- `MESHERY_API_TOKEN`
+- `MESHERY_PROVIDER`
+
+## Using Multiple Meshery Contexts
+
+Multiple Meshery instances can be configured in the same file.
+
+Example:
+
+    current-context: dev
+
+    contexts:
+      dev:
+        server: http://localhost:9081
+        token: <development-token>
+        provider: Meshery
+
+      staging:
+        server: https://staging.example.com
+        token: <staging-token>
+        provider: Meshery
+
+      production:
+        server: https://meshery.example.com
+        token: <production-token>
+        provider: Meshery
+
+The active context is selected using `current-context`.
+
+You can also select a context using:
+
+    export MESHERY_CONTEXT=staging
+
+## Configuration Validation
+
+The configuration is validated when loaded.
+
+The active context must:
+
+- Exist in the `contexts` map.
+- Have a non-empty `server` value.
+- Have a valid server URL.
+
+The configuration parser also rejects unknown YAML fields.
+
+For example, a configuration using an unsupported field such as:
+
+    contexts:
+      dev:
+        endpoint: http://localhost:9081
+
+is rejected.
+
+Use `server` instead:
+
+    contexts:
+      dev:
+        server: http://localhost:9081
+
+## Authentication
+
+Authenticated Meshery requests use the configured API token and provider.
+
+Example:
+
+    contexts:
+      dev:
+        server: http://localhost:9081
+        token: <your-meshery-api-token>
+        provider: Meshery
+
+Keep credentials private and never commit real tokens to source control.
+
+## Environment-Only Configuration
+
+For a quick local setup without a configuration file, set the environment variables:
+
+    export MESHERY_SERVER_URL=http://localhost:9081
+    export MESHERY_API_TOKEN=<your-meshery-api-token>
+    export MESHERY_PROVIDER=Meshery
 
 On PowerShell:
 
     $env:MESHERY_SERVER_URL="http://localhost:9081"
+    $env:MESHERY_API_TOKEN="<your-meshery-api-token>"
+    $env:MESHERY_PROVIDER="Meshery"
 
-## Meshery API Token
-
-Authentication can be configured with the Meshery provider/API token.
-
-Environment variable:
-
-`MESHERY_API_TOKEN`
-
-Example:
-
-    MESHERY_API_TOKEN=your-token
-
-Do not commit tokens or other credentials to source control.
-
-## Configuration File
-
-A configuration-file based setup is planned for the server.
-
-The supported file path, format, fields, and precedence rules should be documented here once the configuration implementation is finalized.
-
-## Command-Line Configuration
-
-Command-line flags will be documented here when they are implemented.
-
-## Environment Variables
-
-| Variable | Description | Default |
-| --- | --- | --- |
-| `MESHERY_SERVER_URL` | URL of the Meshery server | `http://localhost:9081` |
-| `MESHERY_API_TOKEN` | Meshery provider/API token | Not set |
-
-## Configuration Precedence
-
-The final configuration precedence will be documented when the implementation is finalized.
+If no configuration file is found, these environment variables are used to create the default context.
 
 ## Security
 
-- Never commit API tokens to Git.
-- Do not place credentials in public documentation examples.
-- Prefer environment variables or a local configuration file for development credentials.
-- Use appropriate secret-management facilities for production deployments.
+- Never commit API tokens to source control.
+- Do not place real credentials in documentation examples.
+- Use environment variables or a local configuration file for development credentials.
+- Protect configuration files containing authentication tokens.
 
 ## Related Documentation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,30 +30,26 @@ The configuration file can contain multiple Meshery contexts.
 | Field | Description |
 | --- | --- |
 | `current-context` | Name of the currently active context |
-| `contexts` | Map containing the configured Meshery contexts |
+| `contexts` | Map containing configured Meshery contexts |
 | `server` | Base URL of the Meshery Server REST API |
 | `token` | API token used for authentication |
-| `provider` | Meshery provider name, such as `Meshery` or `None` |
+| `provider` | Meshery provider name |
 
-The active context must exist in the `contexts` map and must contain a valid server URL.
+The active context must exist in `contexts` and must contain a valid server URL.
 
 ## Custom Configuration File
 
-To use a configuration file at a different location, set:
-
-    MESHERY_CONFIG_PATH
-
-Example:
+Set `MESHERY_CONFIG_PATH` to use a different configuration file:
 
     export MESHERY_CONFIG_PATH=/path/to/mcp-config.yaml
 
-On PowerShell:
+PowerShell:
 
-    $env:MESHERY_CONFIG_PATH="C:\path\to\mcp-config.yaml"
+    $env:MESHERY_CONFIG_PATH="C:\path	o\mcp-config.yaml"
 
 ## Environment Variables
 
-Environment variables can be used instead of a configuration file or to override values in the active context.
+Environment variables can be used instead of a configuration file or to override values from the active context.
 
 ### MESHERY_SERVER_URL
 
@@ -75,15 +71,15 @@ PowerShell:
 
 Specifies the Meshery API token used for authentication.
 
+Replace `<your-meshery-api-token>` with your real Meshery API token. Do not include a real token in documentation or source control.
+
 Example:
 
-    export MESHERY_API_TOKEN=<your-meshery-api-token>
+    export MESHERY_API_TOKEN="<your-meshery-api-token>"
 
 PowerShell:
 
     $env:MESHERY_API_TOKEN="<your-meshery-api-token>"
-
-Do not commit API tokens or other credentials to Git.
 
 ### MESHERY_PROVIDER
 
@@ -99,7 +95,7 @@ PowerShell:
 
 ### MESHERY_CONTEXT
 
-Specifies which configured context should be active.
+Specifies the configured context to use.
 
 Example:
 
@@ -109,28 +105,24 @@ PowerShell:
 
     $env:MESHERY_CONTEXT="production"
 
-If the specified context does not exist, the existing configured context selection is not replaced.
+If the specified context does not exist, the configured context selection is not replaced.
 
 ## Configuration Priority
 
-When the configuration is loaded, Meshery MCP Server:
+When configuration is loaded:
 
-1. Attempts to load the configuration file.
-2. If the configuration file does not exist, creates a configuration from environment variables.
-3. Applies environment variable overrides to the active context.
+1. The configuration file is loaded when available.
+2. If the configuration file is unavailable, environment variables can provide the configuration.
+3. Environment variables override values for the active context.
 
-Environment variables override configuration-file values for the active context.
-
-The following environment variables can override configuration:
+The following variables can override configuration:
 
 - `MESHERY_CONTEXT`
 - `MESHERY_SERVER_URL`
 - `MESHERY_API_TOKEN`
 - `MESHERY_PROVIDER`
 
-## Using Multiple Meshery Contexts
-
-Multiple Meshery instances can be configured in the same file.
+## Multiple Meshery Contexts
 
 Example:
 
@@ -154,11 +146,15 @@ Example:
 
 The active context is selected using `current-context`.
 
-You can also select a context using:
+You can override it with:
 
     export MESHERY_CONTEXT=staging
 
-## Configuration Validation
+PowerShell:
+
+    $env:MESHERY_CONTEXT="staging"
+
+## Validation
 
 The configuration is validated when loaded.
 
@@ -168,56 +164,34 @@ The active context must:
 - Have a non-empty `server` value.
 - Have a valid server URL.
 
-The configuration parser also rejects unknown YAML fields.
-
-For example, a configuration using an unsupported field such as:
-
-    contexts:
-      dev:
-        endpoint: http://localhost:9081
-
-is rejected.
-
-Use `server` instead:
-
-    contexts:
-      dev:
-        server: http://localhost:9081
+Unknown YAML fields are rejected.
 
 ## Authentication
 
 Authenticated Meshery requests use the configured API token and provider.
 
-Example:
-
-    contexts:
-      dev:
-        server: http://localhost:9081
-        token: <your-meshery-api-token>
-        provider: Meshery
-
-Keep credentials private and never commit real tokens to source control.
+Keep credentials private and never commit real tokens.
 
 ## Environment-Only Configuration
 
-For a quick local setup without a configuration file, set the environment variables:
+For a local setup without a configuration file:
 
     export MESHERY_SERVER_URL=http://localhost:9081
-    export MESHERY_API_TOKEN=<your-meshery-api-token>
+    export MESHERY_API_TOKEN="<your-meshery-api-token>"
     export MESHERY_PROVIDER=Meshery
 
-On PowerShell:
+PowerShell:
 
     $env:MESHERY_SERVER_URL="http://localhost:9081"
     $env:MESHERY_API_TOKEN="<your-meshery-api-token>"
     $env:MESHERY_PROVIDER="Meshery"
 
-If no configuration file is found, these environment variables are used to create the default context.
+Replace the token placeholder with your real Meshery API token before using the configuration.
 
 ## Security
 
 - Never commit API tokens to source control.
-- Do not place real credentials in documentation examples.
+- Never put real credentials in documentation examples.
 - Use environment variables or a local configuration file for development credentials.
 - Protect configuration files containing authentication tokens.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,10 +16,161 @@ The project is being developed incrementally, including:
 - MCP server functionality
 - Meshery API client functionality
 - MCP tools
-- MCP resources
-- MCP prompts
-- Tests
-- Documentation
+- MCP resources# Development Guide
+
+Meshery MCP Server is currently under active development.
+
+The current implementation is a Go-based development foundation with a stdio entrypoint and an initial `ping` operation.
+
+## Repository Setup
+
+Clone the repository:
+
+    git clone https://github.com/meshery-extensions/meshery-mcp-server.git
+    cd meshery-mcp-server
+
+## Project Structure
+
+The current MCP foundation includes:
+
+    cmd/
+      server/
+        main.go
+
+    internal/
+      mcp/
+        server.go
+        server_test.go
+
+The `cmd/server/` directory contains the executable entrypoint.
+
+The `internal/mcp/` directory contains the server logic and its tests.
+
+## Run the Server
+
+Start the current development server with:
+
+    go run cmd/server/main.go
+
+The server reads JSON input from standard input and writes JSON responses to standard output.
+
+For the current development ping operation, send:
+
+    {"method":"ping"}
+
+Expected response:
+
+    {"result":"pong"}
+
+## Format the Code
+
+Format Go source files with:
+
+    go fmt ./...
+
+## Static Analysis
+
+Run Go's vet checks with:
+
+    go vet ./...
+
+## Run Tests
+
+Run the Go test suite with:
+
+    go test ./...
+
+The current MCP foundation includes an initial unit test for the server logic.
+
+## Development Workflow
+
+When implementing a change:
+
+1. Create a focused branch.
+2. Make the smallest change needed for the issue.
+3. Add or update tests.
+4. Format the Go code.
+5. Run `go vet`.
+6. Run `go test`.
+7. Update documentation when behavior changes.
+8. Review the Git diff before committing.
+9. Open a pull request that references the related issue.
+
+## Adding MCP Functionality
+
+The project is being expanded from the initial stdio foundation toward full MCP functionality.
+
+Future implementation areas include:
+
+- MCP protocol support.
+- Streamable HTTP transport.
+- MCP tools.
+- MCP resources.
+- MCP prompts.
+- Meshery API integration.
+- Tests for client and server behavior.
+
+When adding functionality, keep implementation, tests, and documentation synchronized.
+
+## Testing Stdio Behavior
+
+The current development server can be tested manually by starting:
+
+    go run cmd/server/main.go
+
+Then sending:
+
+    {"method":"ping"}
+
+Expected output:
+
+    {"result":"pong"}
+
+As the MCP protocol implementation evolves, tests should cover the actual protocol request/response path used by the executable.
+
+## Validation Before a Pull Request
+
+Run:
+
+    go fmt ./...
+    go vet ./...
+    go test ./...
+
+Also run:
+
+    git diff --check
+
+Review the output of:
+
+    git status
+    git diff
+
+before creating the pull request.
+
+## Documentation
+
+Update the relevant documentation when changing user-visible behavior:
+
+- [Installation](installation.md)
+- [Configuration](configuration.md)
+- [Tools Reference](tools-reference.md)
+
+## Current Limitations
+
+The current development foundation is not the completed Meshery MCP Server.
+
+In particular, the initial stdio foundation does not yet represent the final MCP feature set. Streamable HTTP transport, complete MCP protocol behavior, and the complete Meshery tool/resource/prompt surface are part of the ongoing implementation.
+
+Do not document development-only behavior as a production-ready feature.
+
+## Community
+
+Contributions should follow the repository's contribution guidelines and the CNCF Code of Conduct.
+
+See:
+
+- [Contributing Guide](../CONTRIBUTING.md)
+- [Code of Conduct](../CODE_OF_CONDUCT.md)
 
 ## Prerequisites
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,26 +1,8 @@
 # Development Guide
 
-## Repository
+> **Status:** Meshery MCP Server is currently under active development.
 
-Clone the official repository:
-
-    git clone https://github.com/meshery-extensions/meshery-mcp-server.git
-    cd meshery-mcp-server
-
-## Project Status
-
-Meshery MCP Server is currently under active development.
-
-The project is being developed incrementally, including:
-
-- MCP server functionality
-- Meshery API client functionality
-- MCP tools
-- MCP resources# Development Guide
-
-Meshery MCP Server is currently under active development.
-
-The current implementation is a Go-based development foundation with a stdio entrypoint and an initial `ping` operation.
+The current implementation is a Go-based Meshery MCP Server with a stdio entrypoint.
 
 ## Repository Setup
 
@@ -31,56 +13,105 @@ Clone the repository:
 
 ## Project Structure
 
-The current MCP foundation includes:
+The server executable is located at:
 
-    cmd/
-      server/
-        main.go
+    cmd/meshery-mcp-server/main.go
 
-    internal/
-      mcp/
-        server.go
-        server_test.go
+The repository also contains internal packages for MCP, Meshery client, resources, and version information.
 
-The `cmd/server/` directory contains the executable entrypoint.
+## Build
 
-The `internal/mcp/` directory contains the server logic and its tests.
+The repository Makefile provides the tested build target:
 
-## Run the Server
+    make build
 
-Start the current development server with:
+The binary is written to:
 
-    go run cmd/server/main.go
+    bin/meshery-mcp-server
 
-The server reads JSON input from standard input and writes JSON responses to standard output.
+The CI workflow also verifies that the repository builds with:
 
-For the current development ping operation, send:
+    go build ./...
 
-    {"method":"ping"}
+## Run
 
-Expected response:
+Run the server through the Makefile:
 
-    {"result":"pong"}
+    make run
 
-## Format the Code
+The `run` target builds the binary and starts the Meshery MCP Server over stdio.
 
-Format Go source files with:
+## Test
 
-    go fmt ./...
+Run the repository test target:
 
-## Static Analysis
+    make test
 
-Run Go's vet checks with:
+The test target runs:
+
+    go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
+
+The CI workflow uses the same test command.
+
+## Vet
+
+Run:
+
+    make vet
+
+The underlying command is:
 
     go vet ./...
 
-## Run Tests
+## Formatting
 
-Run the Go test suite with:
+Run:
 
-    go test ./...
+    make fmt
 
-The current MCP foundation includes an initial unit test for the server logic.
+The repository uses `golangci-lint fmt` for formatting.
+
+## Linting
+
+Run:
+
+    make lint
+
+The underlying command is:
+
+    golangci-lint run --timeout=10m
+
+## Docker
+
+Build the development container image with:
+
+    make docker-build
+
+The Makefile tags the image as:
+
+    meshery/meshery-mcp-server
+
+The Dockerfile builds the `cmd/meshery-mcp-server` binary and uses it as the container entrypoint.
+
+## Clean Build Artifacts
+
+Run:
+
+    make clean
+
+This removes the `bin` directory and `coverage.txt`.
+
+## CI Validation
+
+The repository build-and-test workflow verifies:
+
+    go build ./...
+    go vet ./...
+    go test --short ./... -race -coverprofile=coverage.txt -covermode=atomic
+
+The workflow also runs golangci-lint.
+
+The inspected CI workflow does not currently define a separate Markdown linting or documentation-example validation command. Do not document an unconfigured command as a repository requirement.
 
 ## Development Workflow
 
@@ -89,164 +120,31 @@ When implementing a change:
 1. Create a focused branch.
 2. Make the smallest change needed for the issue.
 3. Add or update tests.
-4. Format the Go code.
-5. Run `go vet`.
-6. Run `go test`.
-7. Update documentation when behavior changes.
-8. Review the Git diff before committing.
-9. Open a pull request that references the related issue.
+4. Run formatting.
+5. Run linting.
+6. Run `make build`.
+7. Run `make test`.
+8. Run `make vet`.
+9. Review the Git diff.
+10. Update documentation when behavior changes.
+11. Open a pull request that references the related issue.
 
-## Adding MCP Functionality
+## Current MCP Development Status
 
-The project is being expanded from the initial stdio foundation toward full MCP functionality.
+MCP functionality is under active development. Keep documentation aligned with the implementation actually present in the branch being documented.
 
-Future implementation areas include:
-
-- MCP protocol support.
-- Streamable HTTP transport.
-- MCP tools.
-- MCP resources.
-- MCP prompts.
-- Meshery API integration.
-- Tests for client and server behavior.
-
-When adding functionality, keep implementation, tests, and documentation synchronized.
-
-## Testing Stdio Behavior
-
-The current development server can be tested manually by starting:
-
-    go run cmd/server/main.go
-
-Then sending:
-
-    {"method":"ping"}
-
-Expected output:
-
-    {"result":"pong"}
-
-As the MCP protocol implementation evolves, tests should cover the actual protocol request/response path used by the executable.
-
-## Validation Before a Pull Request
-
-Run:
-
-    go fmt ./...
-    go vet ./...
-    go test ./...
-
-Also run:
-
-    git diff --check
-
-Review the output of:
-
-    git status
-    git diff
-
-before creating the pull request.
+Do not document a client integration, transport, tool, resource, or command as production-ready unless it has been implemented and verified.
 
 ## Documentation
 
-Update the relevant documentation when changing user-visible behavior:
+Update the relevant documentation when behavior changes:
 
 - [Installation](installation.md)
 - [Configuration](configuration.md)
-- [Tools Reference](tools-reference.md)
+- [Tools and Resources Reference](tools-reference.md)
 
-## Current Limitations
+## Related Documentation
 
-The current development foundation is not the completed Meshery MCP Server.
-
-In particular, the initial stdio foundation does not yet represent the final MCP feature set. Streamable HTTP transport, complete MCP protocol behavior, and the complete Meshery tool/resource/prompt surface are part of the ongoing implementation.
-
-Do not document development-only behavior as a production-ready feature.
-
-## Community
-
-Contributions should follow the repository's contribution guidelines and the CNCF Code of Conduct.
-
-See:
-
-- [Contributing Guide](../CONTRIBUTING.md)
-- [Code of Conduct](../CODE_OF_CONDUCT.md)
-
-## Prerequisites
-
-For development, install:
-
-- Git
-- Go, when building the Go implementation
-- A running Meshery instance when testing Meshery API integration
-
-See the [Meshery Quick Start](https://docs.meshery.io/installation/quick-start/) for Meshery setup information.
-
-## Building
-
-Build instructions will be updated when the Go application structure and official build target are finalized.
-
-Do not assume a build command that is not provided by the repository's current implementation.
-
-## Testing
-
-Tests should be added alongside implementation changes.
-
-Before opening a pull request:
-
-1. Run the repository's available tests.
-2. Run formatting and linting checks.
-3. Verify documentation examples.
-4. Confirm that changes do not introduce unrelated failures.
-
-The exact project test commands will be documented here once the implementation is available.
-
-## Adding an MCP Tool
-
-When the MCP tool architecture is finalized, a new tool should generally:
-
-1. Define the tool's purpose.
-2. Define its input schema.
-3. Implement the handler.
-4. Connect it to the appropriate Meshery API/client functionality.
-5. Register the tool with the MCP server.
-6. Add unit tests.
-7. Document the tool in `tools-reference.md`.
-8. Add a working example where appropriate.
-
-## Adding an MCP Resource
-
-A new MCP resource should:
-
-1. Define its URI.
-2. Define the returned data.
-3. Implement the resource handler.
-4. Register it with the server.
-5. Add tests.
-6. Document it.
-
-## Adding an MCP Prompt
-
-A new MCP prompt should:
-
-1. Define its purpose.
-2. Define its arguments.
-3. Implement the prompt.
-4. Register it with the server.
-5. Add tests.
-6. Document its usage.
-
-## Pull Requests
-
-Before opening a pull request:
-
-1. Keep the change focused.
-2. Add or update tests when applicable.
-3. Update documentation.
-4. Run available validation and linting commands.
-5. Write a clear pull request description.
-6. Reference the related GitHub issue.
-
-## Code of Conduct
-
-Contributors are expected to follow the project's [Code of Conduct](../CODE_OF_CONDUCT.md).
+- [Installation](installation.md)
+- [Configuration](configuration.md)
+- [Tools and Resources Reference](tools-reference.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,7 +111,9 @@ The repository build-and-test workflow verifies:
 
 The workflow also runs golangci-lint.
 
-The inspected CI workflow does not currently define a separate Markdown linting or documentation-example validation command. Do not document an unconfigured command as a repository requirement.
+A README Markdown linting command is not currently configured in the repository CI workflow. Therefore, README Markdown linting as a merge acceptance requirement is deferred until a corresponding CI check is added.
+
+Do not document or claim an unconfigured Markdown linting command as a repository requirement.
 
 ## Development Workflow
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,101 @@
+# Development Guide
+
+## Repository
+
+Clone the official repository:
+
+    git clone https://github.com/meshery-extensions/meshery-mcp-server.git
+    cd meshery-mcp-server
+
+## Project Status
+
+Meshery MCP Server is currently under active development.
+
+The project is being developed incrementally, including:
+
+- MCP server functionality
+- Meshery API client functionality
+- MCP tools
+- MCP resources
+- MCP prompts
+- Tests
+- Documentation
+
+## Prerequisites
+
+For development, install:
+
+- Git
+- Go, when building the Go implementation
+- A running Meshery instance when testing Meshery API integration
+
+See the [Meshery Quick Start](https://docs.meshery.io/installation/quick-start/) for Meshery setup information.
+
+## Building
+
+Build instructions will be updated when the Go application structure and official build target are finalized.
+
+Do not assume a build command that is not provided by the repository's current implementation.
+
+## Testing
+
+Tests should be added alongside implementation changes.
+
+Before opening a pull request:
+
+1. Run the repository's available tests.
+2. Run formatting and linting checks.
+3. Verify documentation examples.
+4. Confirm that changes do not introduce unrelated failures.
+
+The exact project test commands will be documented here once the implementation is available.
+
+## Adding an MCP Tool
+
+When the MCP tool architecture is finalized, a new tool should generally:
+
+1. Define the tool's purpose.
+2. Define its input schema.
+3. Implement the handler.
+4. Connect it to the appropriate Meshery API/client functionality.
+5. Register the tool with the MCP server.
+6. Add unit tests.
+7. Document the tool in `tools-reference.md`.
+8. Add a working example where appropriate.
+
+## Adding an MCP Resource
+
+A new MCP resource should:
+
+1. Define its URI.
+2. Define the returned data.
+3. Implement the resource handler.
+4. Register it with the server.
+5. Add tests.
+6. Document it.
+
+## Adding an MCP Prompt
+
+A new MCP prompt should:
+
+1. Define its purpose.
+2. Define its arguments.
+3. Implement the prompt.
+4. Register it with the server.
+5. Add tests.
+6. Document its usage.
+
+## Pull Requests
+
+Before opening a pull request:
+
+1. Keep the change focused.
+2. Add or update tests when applicable.
+3. Update documentation.
+4. Run available validation and linting commands.
+5. Write a clear pull request description.
+6. Reference the related GitHub issue.
+
+## Code of Conduct
+
+Contributors are expected to follow the project's [Code of Conduct](../CODE_OF_CONDUCT.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,86 +2,103 @@
 
 > **Status:** Meshery MCP Server is currently under active development.
 
-Meshery MCP Server is an official Meshery extension that provides an MCP interface for interacting with Meshery from MCP-compatible clients.
+Meshery MCP Server is being developed as an official Meshery extension that provides an MCP interface for Meshery.
 
 ## Prerequisites
 
-Before working with Meshery MCP Server, you should have:
+Before running the current development server, install:
 
-- A running Meshery instance.
-- An MCP-compatible client.
-- Git installed.
-- Go installed if you plan to build the server from source.
+- Git
+- Go
+- A running Meshery instance when testing Meshery integration
 
-For information about installing Meshery, see the [Meshery Quick Start](https://docs.meshery.io/installation/quick-start/).
+The current MCP server foundation is implemented as a Go application and provides a stdio entrypoint under `cmd/server/`.
 
 ## Clone the Repository
 
-Clone the official Meshery MCP Server repository:
+Clone the official repository:
 
     git clone https://github.com/meshery-extensions/meshery-mcp-server.git
     cd meshery-mcp-server
 
-## Build from Source
+## Run the Development Server
 
-The Meshery MCP Server is currently under active development.
+The current development implementation can be started with:
 
-The repository does not yet provide a finalized Go module, build target, or release binary. Therefore, the exact build and run commands will be documented here once the implementation is available.
+    go run cmd/server/main.go
 
-The expected source-build workflow is:
+The server reads JSON input from standard input and writes JSON responses to standard output.
 
-    git clone https://github.com/meshery-extensions/meshery-mcp-server.git
-    cd meshery-mcp-server
+## Test the Ping Tool
 
-    # Build and run commands will be added
-    # when the server implementation is finalized.
+The current development foundation includes a simple `ping` operation.
 
-## Pre-built Binaries
+Start the server:
 
-Official pre-built binaries will be documented here when Meshery MCP Server releases are published.
+    go run cmd/server/main.go
 
-The release documentation will include:
+Then provide:
 
-- Supported operating systems.
-- Supported CPU architectures.
-- Download locations.
-- Installation instructions.
-- Version verification.
+    {"method":"ping"}
 
-## Docker
+The expected response from the current foundation is:
 
-Docker installation will be documented once an official Meshery MCP Server container image is published.
+    {"result":"pong"}
 
-The documentation will include:
+This is a development bootstrap and is not yet a complete MCP client integration.
 
-- Official container image name.
-- Available image tags.
-- Required environment variables.
-- Port configuration.
-- Example Docker commands.
+## Current Transport
 
-## Homebrew
+The current foundation implements communication over standard input and standard output (stdio).
 
-Homebrew installation instructions will be added when an official Homebrew distribution becomes available.
+Streamable HTTP transport is planned as future work.
 
-## Verify the Installation
+## Current Development Status
 
-Once the server implementation and command-line interface are finalized, this section will document how to verify the installation.
+The current implementation is a minimal foundation. It includes:
 
-Verification should confirm that:
+- A Go module.
+- A `cmd/server/` entrypoint.
+- Internal MCP server logic.
+- Stdio input/output handling.
+- A basic `ping` operation.
+- Initial unit tests.
 
-1. Meshery MCP Server starts successfully.
-2. The server can communicate with Meshery.
-3. An MCP-compatible client can connect to the server.
-4. MCP tools and resources can be discovered.
+Full MCP protocol support, additional tools, resources, prompts, and production-ready client integrations are still under development.
+
+## Configuration
+
+Meshery connection and authentication settings are documented in the [Configuration Guide](configuration.md).
+
+## Troubleshooting
+
+### Go command is not available
+
+Verify that Go is installed:
+
+    go version
+
+### Server does not start
+
+Run the command from the repository root:
+
+    go run cmd/server/main.go
+
+### Ping does not return the expected response
+
+Make sure the input is valid JSON and uses the current development request format:
+
+    {"method":"ping"}
+
+### MCP client cannot connect
+
+The current development foundation uses stdio and is not yet a finalized MCP client integration. Verify that the client configuration matches the server transport and implementation available in your checkout.
 
 ## Next Steps
 
-After installing Meshery MCP Server:
+After running the development server:
 
-1. Configure the Meshery server URL.
-2. Configure authentication if required.
-3. Configure your MCP-compatible client.
-4. Start the MCP server.
-5. Verify the connection.
-6. Use the available MCP tools and resources.
+1. Review the [Configuration Guide](configuration.md).
+2. Review the [Tools Reference](tools-reference.md).
+3. Review the [Development Guide](development.md).
+4. Follow the project's ongoing implementation work for complete MCP support.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,17 +30,35 @@ The repository provides a Makefile build target:
 
     make build
 
-This builds:
+This builds the Meshery MCP Server executable at:
 
     bin/meshery-mcp-server
 
-The equivalent Go build command used by CI is:
+The server entrypoint used by the build is:
+
+    ./cmd/meshery-mcp-server
+
+The CI workflow separately validates that the repository builds successfully with:
 
     go build ./...
 
-The server entrypoint is:
+The `go build ./...` command validates the Go packages; it is not equivalent to the `make build` target.
 
-    cmd/meshery-mcp-server/main.go
+## Verify the Built Server
+
+After running:
+
+    make build
+
+verify that the executable exists:
+
+PowerShell:
+
+    Test-Path .\bin\meshery-mcp-server.exe
+
+Linux/macOS:
+
+    test -f ./bin/meshery-mcp-server
 
 ## Run from Source
 
@@ -52,7 +70,7 @@ The Makefile builds the binary and starts it over stdio.
 
 ## Docker
 
-The repository includes a Dockerfile and a Makefile target for building a container image.
+The repository includes a Dockerfile and a Makefile target for building the container image.
 
 Build the image with:
 
@@ -62,13 +80,21 @@ The image is tagged:
 
     meshery/meshery-mcp-server
 
-The Dockerfile builds the server binary from:
+The Dockerfile builds the server from:
 
     ./cmd/meshery-mcp-server
 
-and uses `/meshery-mcp-server` as the container entrypoint.
+and uses:
 
-The repository currently documents how to build the Docker image locally. A published container registry location is not documented here because it has not been verified from the current implementation.
+    /meshery-mcp-server
+
+as the container entrypoint.
+
+A verified Docker stdio invocation is not currently established in the repository documentation or CI workflow. Therefore, Docker stdio client integration is deferred until a tested invocation and verification flow are added.
+
+For now, the supported documented Docker operation is building the image locally with:
+
+    make docker-build
 
 ## Pre-built Binaries
 
@@ -88,13 +114,13 @@ Use the source build or Docker method described above.
 
 ## Server Version
 
-The server contains version metadata that is embedded during builds.
+The build embeds the Git version and commit SHA into the server binary.
 
-The Makefile derives the Git version and commit SHA and passes them to the build using linker flags.
+The Makefile derives these values during the build.
 
-A stable end-user version command is not documented here unless it is provided by the executable in the implementation being used.
+A verified end-user `--version` command is not currently established in the repository documentation.
 
-For development builds, identify the exact source revision with:
+To identify the source revision used for a development build, run:
 
     git describe --tags --always --dirty
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,87 @@
+# Installation
+
+> **Status:** Meshery MCP Server is currently under active development.
+
+Meshery MCP Server is an official Meshery extension that provides an MCP interface for interacting with Meshery from MCP-compatible clients.
+
+## Prerequisites
+
+Before working with Meshery MCP Server, you should have:
+
+- A running Meshery instance.
+- An MCP-compatible client.
+- Git installed.
+- Go installed if you plan to build the server from source.
+
+For information about installing Meshery, see the [Meshery Quick Start](https://docs.meshery.io/installation/quick-start/).
+
+## Clone the Repository
+
+Clone the official Meshery MCP Server repository:
+
+    git clone https://github.com/meshery-extensions/meshery-mcp-server.git
+    cd meshery-mcp-server
+
+## Build from Source
+
+The Meshery MCP Server is currently under active development.
+
+The repository does not yet provide a finalized Go module, build target, or release binary. Therefore, the exact build and run commands will be documented here once the implementation is available.
+
+The expected source-build workflow is:
+
+    git clone https://github.com/meshery-extensions/meshery-mcp-server.git
+    cd meshery-mcp-server
+
+    # Build and run commands will be added
+    # when the server implementation is finalized.
+
+## Pre-built Binaries
+
+Official pre-built binaries will be documented here when Meshery MCP Server releases are published.
+
+The release documentation will include:
+
+- Supported operating systems.
+- Supported CPU architectures.
+- Download locations.
+- Installation instructions.
+- Version verification.
+
+## Docker
+
+Docker installation will be documented once an official Meshery MCP Server container image is published.
+
+The documentation will include:
+
+- Official container image name.
+- Available image tags.
+- Required environment variables.
+- Port configuration.
+- Example Docker commands.
+
+## Homebrew
+
+Homebrew installation instructions will be added when an official Homebrew distribution becomes available.
+
+## Verify the Installation
+
+Once the server implementation and command-line interface are finalized, this section will document how to verify the installation.
+
+Verification should confirm that:
+
+1. Meshery MCP Server starts successfully.
+2. The server can communicate with Meshery.
+3. An MCP-compatible client can connect to the server.
+4. MCP tools and resources can be discovered.
+
+## Next Steps
+
+After installing Meshery MCP Server:
+
+1. Configure the Meshery server URL.
+2. Configure authentication if required.
+3. Configure your MCP-compatible client.
+4. Start the MCP server.
+5. Verify the connection.
+6. Use the available MCP tools and resources.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,17 +2,20 @@
 
 > **Status:** Meshery MCP Server is currently under active development.
 
-Meshery MCP Server is being developed as an official Meshery extension that provides an MCP interface for Meshery.
+This guide documents installation methods supported by the current development repository.
 
 ## Prerequisites
 
-Before running the current development server, install:
+For building from source, install:
 
 - Git
-- Go
-- A running Meshery instance when testing Meshery integration
+- Go 1.26.0 or a compatible Go release supported by the repository
 
-The current MCP server foundation is implemented as a Go application and provides a stdio entrypoint under `cmd/server/`.
+Verify Go:
+
+    go version
+
+The repository's `go.mod` declares Go 1.26.0.
 
 ## Clone the Repository
 
@@ -21,84 +24,136 @@ Clone the official repository:
     git clone https://github.com/meshery-extensions/meshery-mcp-server.git
     cd meshery-mcp-server
 
-## Run the Development Server
+## Build from Source
 
-The current development implementation can be started with:
+The repository provides a Makefile build target:
 
-    go run cmd/server/main.go
+    make build
 
-The server reads JSON input from standard input and writes JSON responses to standard output.
+This builds:
 
-## Test the Ping Tool
+    bin/meshery-mcp-server
 
-The current development foundation includes a simple `ping` operation.
+The equivalent Go build command used by CI is:
 
-Start the server:
+    go build ./...
 
-    go run cmd/server/main.go
+The server entrypoint is:
 
-Then provide:
+    cmd/meshery-mcp-server/main.go
 
-    {"method":"ping"}
+## Run from Source
 
-The expected response from the current foundation is:
+Run the development server with:
 
-    {"result":"pong"}
+    make run
 
-This is a development bootstrap and is not yet a complete MCP client integration.
+The Makefile builds the binary and starts it over stdio.
 
-## Current Transport
+## Docker
 
-The current foundation implements communication over standard input and standard output (stdio).
+The repository includes a Dockerfile and a Makefile target for building a container image.
 
-Streamable HTTP transport is planned as future work.
+Build the image with:
 
-## Current Development Status
+    make docker-build
 
-The current implementation is a minimal foundation. It includes:
+The image is tagged:
 
-- A Go module.
-- A `cmd/server/` entrypoint.
-- Internal MCP server logic.
-- Stdio input/output handling.
-- A basic `ping` operation.
-- Initial unit tests.
+    meshery/meshery-mcp-server
 
-Full MCP protocol support, additional tools, resources, prompts, and production-ready client integrations are still under development.
+The Dockerfile builds the server binary from:
+
+    ./cmd/meshery-mcp-server
+
+and uses `/meshery-mcp-server` as the container entrypoint.
+
+The repository currently documents how to build the Docker image locally. A published container registry location is not documented here because it has not been verified from the current implementation.
+
+## Pre-built Binaries
+
+The repository contains release/build configuration, but this guide does not claim a public pre-built binary download URL because a verified release artifact location was not established from the implementation reviewed for this documentation.
+
+For a guaranteed reproducible local installation, build from source with:
+
+    make build
+
+## Homebrew
+
+A Homebrew formula was not identified in the reviewed Meshery MCP Server implementation.
+
+Therefore, Homebrew installation is currently **not documented as a supported installation method**.
+
+Use the source build or Docker method described above.
+
+## Server Version
+
+The server contains version metadata that is embedded during builds.
+
+The Makefile derives the Git version and commit SHA and passes them to the build using linker flags.
+
+A stable end-user version command is not documented here unless it is provided by the executable in the implementation being used.
+
+For development builds, identify the exact source revision with:
+
+    git describe --tags --always --dirty
+
+and:
+
+    git rev-parse --short HEAD
 
 ## Configuration
 
 Meshery connection and authentication settings are documented in the [Configuration Guide](configuration.md).
 
+## Verify the Installation
+
+Build and validate the server:
+
+    make build
+    make test
+    make vet
+
+Then run:
+
+    make run
+
+For Docker:
+
+    make docker-build
+
 ## Troubleshooting
 
-### Go command is not available
+### Go is not installed
 
-Verify that Go is installed:
+Install Go and verify:
 
     go version
 
-### Server does not start
+### Build fails
 
-Run the command from the repository root:
+Run from the repository root and verify dependencies:
 
-    go run cmd/server/main.go
+    go mod download
 
-### Ping does not return the expected response
+Then:
 
-Make sure the input is valid JSON and uses the current development request format:
+    make build
 
-    {"method":"ping"}
+### Tests fail
 
-### MCP client cannot connect
+Run:
 
-The current development foundation uses stdio and is not yet a finalized MCP client integration. Verify that the client configuration matches the server transport and implementation available in your checkout.
+    make test
 
-## Next Steps
+### Linting fails
 
-After running the development server:
+Run:
 
-1. Review the [Configuration Guide](configuration.md).
-2. Review the [Tools Reference](tools-reference.md).
-3. Review the [Development Guide](development.md).
-4. Follow the project's ongoing implementation work for complete MCP support.
+    make lint
+
+## Related Documentation
+
+- [Configuration](configuration.md)
+- [Tools and Resources Reference](tools-reference.md)
+- [Development Guide](development.md)

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -1,0 +1,59 @@
+# Claude Desktop Integration
+
+> **Status:** Meshery MCP Server is currently under active development.
+
+This guide will document how to connect Claude Desktop to Meshery MCP Server once the server implementation and supported transport are finalized.
+
+## Prerequisites
+
+- Claude Desktop
+- A running Meshery instance
+- A working Meshery MCP Server installation
+
+See the [Installation Guide](../installation.md) for project setup.
+
+## MCP Server Configuration
+
+Claude Desktop uses an MCP server configuration to start or connect to MCP servers.
+
+The final Meshery MCP Server configuration will be documented here after the supported command and transport are finalized.
+
+Expected structure:
+
+    {
+      "mcpServers": {
+        "meshery": {
+          "command": "<meshery-mcp-server-command>",
+          "args": []
+        }
+      }
+    }
+
+Replace the placeholder command with the actual published Meshery MCP Server command.
+
+## Configuration
+
+Meshery connection settings should be configured according to the [Configuration Guide](../configuration.md).
+
+Do not place real API tokens in documentation or source control.
+
+## Verify the Connection
+
+After configuring the client:
+
+1. Restart Claude Desktop.
+2. Open the MCP/tools interface.
+3. Confirm that the Meshery server is available.
+4. Test an available Meshery MCP tool.
+
+## Troubleshooting
+
+If the server cannot be discovered:
+
+- Confirm the executable path.
+- Confirm the Meshery server is reachable.
+- Check the configured environment variables.
+- Check the server logs.
+- Verify that the MCP transport configured by the client matches the server implementation.
+
+The final troubleshooting commands will be added after the implementation is finalized.

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -1,72 +1,61 @@
 # Claude Desktop Integration
 
-> **Status:** Meshery MCP Server is currently under active development.
+> **Status:** Claude Desktop integration is not yet verified for the current development implementation.
 
-The current Meshery MCP Server implementation provides a development stdio foundation. A complete, verified Claude Desktop integration is not yet documented because the final MCP protocol support and client configuration are still under development.
+The repository currently provides a Go-based development server with stdio support. A tested Claude Desktop configuration was not established from the implementation and CI reviewed for this documentation.
 
-## Current Status
+## Current Development Server
 
-The current development server can be started with:
+The repository entrypoint is:
 
-    go run cmd/server/main.go
+    cmd/meshery-mcp-server/main.go
 
-The current foundation reads JSON from standard input and writes JSON to standard output.
+Run it through:
 
-The current development ping request is:
+    make run
 
-    {"method":"ping"}
-
-Expected response:
-
-    {"result":"pong"}
-
-This development interface should not be treated as the final Claude Desktop MCP integration.
+Do not use an unverified Claude Desktop configuration as a production setup.
 
 ## Prerequisites
 
 - Claude Desktop
-- A working Go development environment
+- Meshery MCP Server built from this repository
 - A running Meshery instance when testing Meshery integration
-- A local checkout of Meshery MCP Server
 
 See the [Installation Guide](../installation.md).
 
 ## Configuration
 
-Meshery connection and authentication settings are documented in the [Configuration Guide](../configuration.md).
+Configure Meshery connection and authentication according to the [Configuration Guide](../configuration.md).
 
-Do not place real API tokens or other credentials in source control.
+Never commit real API tokens.
 
-## Claude Desktop Integration
+## Claude Desktop Support
 
-A verified Claude Desktop configuration will be documented after the server's MCP protocol support and supported transport are finalized.
+A complete, tested Claude Desktop configuration requires a verified MCP protocol request/response flow and client configuration.
 
-At the current development stage, this repository does not provide a production-ready Claude Desktop configuration command or configuration snippet.
-
-Do not use an unverified placeholder configuration as a production setup.
+Those details are not established by the current implementation evidence reviewed for this documentation. Therefore this guide intentionally does not provide a fake command, transport, environment-variable list, or unverified JSON configuration.
 
 ## Verification
 
-When Claude Desktop support is finalized, this guide should document:
+When Claude Desktop support is implemented and tested, this guide should document:
 
-1. The exact server command.
-2. The supported MCP transport.
-3. The required client configuration.
+1. The exact executable or command.
+2. The required transport.
+3. The exact Claude Desktop configuration.
 4. Required environment variables.
-5. A verified tool or resource invocation.
+5. A verified Meshery resource or tool invocation.
 6. Expected output.
 
 ## Troubleshooting
 
-For the current development foundation:
+For the current development server:
 
-- Verify that Go is installed with `go version`.
-- Run the server from the repository root.
-- Verify that `go run cmd/server/main.go` starts successfully.
-- Verify the development ping request and response.
-- Check server output for errors.
-
-For Claude Desktop-specific connection problems, use the final verified client configuration once MCP support is completed.
+- Verify Go with `go version`.
+- Run `make build`.
+- Run `make run`.
+- Check stderr for server errors.
+- Verify Meshery configuration separately using the [Configuration Guide](../configuration.md).
 
 ## Related Documentation
 

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -32,9 +32,23 @@ Never commit real API tokens.
 
 ## Claude Desktop Support
 
-A complete, tested Claude Desktop configuration requires a verified MCP protocol request/response flow and client configuration.
+Claude Desktop integration is currently deferred.
 
-Those details are not established by the current implementation evidence reviewed for this documentation. Therefore this guide intentionally does not provide a fake command, transport, environment-variable list, or unverified JSON configuration.
+The repository provides a development stdio server through:
+
+    make run
+
+However, a tested Claude Desktop configuration, required environment-variable set, and verified Claude Desktop MCP request/response flow have not been established in the current repository implementation and CI.
+
+Therefore, this documentation does not provide an unverified Claude Desktop configuration.
+
+The Claude Desktop integration acceptance criterion remains deferred until the following are verified:
+
+1. Exact stdio server command.
+2. Exact Claude Desktop configuration.
+3. Required environment variables.
+4. Successful server startup from Claude Desktop.
+5. A verified MCP request/response or resource/tool invocation.
 
 ## Verification
 

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -2,58 +2,75 @@
 
 > **Status:** Meshery MCP Server is currently under active development.
 
-This guide will document how to connect Claude Desktop to Meshery MCP Server once the server implementation and supported transport are finalized.
+The current Meshery MCP Server implementation provides a development stdio foundation. A complete, verified Claude Desktop integration is not yet documented because the final MCP protocol support and client configuration are still under development.
+
+## Current Status
+
+The current development server can be started with:
+
+    go run cmd/server/main.go
+
+The current foundation reads JSON from standard input and writes JSON to standard output.
+
+The current development ping request is:
+
+    {"method":"ping"}
+
+Expected response:
+
+    {"result":"pong"}
+
+This development interface should not be treated as the final Claude Desktop MCP integration.
 
 ## Prerequisites
 
 - Claude Desktop
-- A running Meshery instance
-- A working Meshery MCP Server installation
+- A working Go development environment
+- A running Meshery instance when testing Meshery integration
+- A local checkout of Meshery MCP Server
 
-See the [Installation Guide](../installation.md) for project setup.
-
-## MCP Server Configuration
-
-Claude Desktop uses an MCP server configuration to start or connect to MCP servers.
-
-The final Meshery MCP Server configuration will be documented here after the supported command and transport are finalized.
-
-Expected structure:
-
-    {
-      "mcpServers": {
-        "meshery": {
-          "command": "<meshery-mcp-server-command>",
-          "args": []
-        }
-      }
-    }
-
-Replace the placeholder command with the actual published Meshery MCP Server command.
+See the [Installation Guide](../installation.md).
 
 ## Configuration
 
-Meshery connection settings should be configured according to the [Configuration Guide](../configuration.md).
+Meshery connection and authentication settings are documented in the [Configuration Guide](../configuration.md).
 
-Do not place real API tokens in documentation or source control.
+Do not place real API tokens or other credentials in source control.
 
-## Verify the Connection
+## Claude Desktop Integration
 
-After configuring the client:
+A verified Claude Desktop configuration will be documented after the server's MCP protocol support and supported transport are finalized.
 
-1. Restart Claude Desktop.
-2. Open the MCP/tools interface.
-3. Confirm that the Meshery server is available.
-4. Test an available Meshery MCP tool.
+At the current development stage, this repository does not provide a production-ready Claude Desktop configuration command or configuration snippet.
+
+Do not use an unverified placeholder configuration as a production setup.
+
+## Verification
+
+When Claude Desktop support is finalized, this guide should document:
+
+1. The exact server command.
+2. The supported MCP transport.
+3. The required client configuration.
+4. Required environment variables.
+5. A verified tool or resource invocation.
+6. Expected output.
 
 ## Troubleshooting
 
-If the server cannot be discovered:
+For the current development foundation:
 
-- Confirm the executable path.
-- Confirm the Meshery server is reachable.
-- Check the configured environment variables.
-- Check the server logs.
-- Verify that the MCP transport configured by the client matches the server implementation.
+- Verify that Go is installed with `go version`.
+- Run the server from the repository root.
+- Verify that `go run cmd/server/main.go` starts successfully.
+- Verify the development ping request and response.
+- Check server output for errors.
 
-The final troubleshooting commands will be added after the implementation is finalized.
+For Claude Desktop-specific connection problems, use the final verified client configuration once MCP support is completed.
+
+## Related Documentation
+
+- [Installation](../installation.md)
+- [Configuration](../configuration.md)
+- [Tools and Resources Reference](../tools-reference.md)
+- [Development Guide](../development.md)

--- a/docs/integrations/cline.md
+++ b/docs/integrations/cline.md
@@ -1,70 +1,62 @@
 # Cline Integration
 
-> **Status:** Meshery MCP Server is currently under active development.
+> **Status:** Cline integration is not yet verified for the current development implementation.
 
-The current Meshery MCP Server implementation provides a development stdio foundation. A complete, verified Cline integration is not yet documented because the final MCP protocol support and client configuration are still under development.
+The repository currently provides a Go-based development server with stdio support. A tested Cline configuration was not established from the implementation and CI reviewed for this documentation.
 
-## Current Status
+## Current Development Server
 
-The current development server can be started with:
+The repository entrypoint is:
 
-    go run cmd/server/main.go
+    cmd/meshery-mcp-server/main.go
 
-The current foundation reads JSON from standard input and writes JSON to standard output.
+Run it through:
 
-The current development ping request is:
+    make run
 
-    {"method":"ping"}
-
-Expected response:
-
-    {"result":"pong"}
-
-This development interface should not be treated as the final Cline MCP integration.
+The server uses stdio for its development interface. Do not use an unverified Cline configuration as a production setup.
 
 ## Prerequisites
 
 - VS Code with Cline installed
-- A working Go development environment
+- Meshery MCP Server built from this repository
 - A running Meshery instance when testing Meshery integration
-- A local checkout of Meshery MCP Server
 
 See the [Installation Guide](../installation.md).
 
 ## Configuration
 
-Meshery connection and authentication settings are documented in the [Configuration Guide](../configuration.md).
+Configure Meshery connection and authentication according to the [Configuration Guide](../configuration.md).
 
-Never commit real credentials.
+Never commit real API tokens.
 
-## Cline Integration
+## Cline Support
 
-A verified Cline configuration will be documented after the server's MCP protocol support and supported transport are finalized.
+A complete, tested Cline configuration requires a verified MCP protocol request/response flow and client configuration.
 
-At the current development stage, this repository does not provide a production-ready Cline configuration command or configuration snippet.
-
-Do not use an unverified placeholder configuration as a production setup.
+Those details are not established by the current implementation evidence reviewed for this documentation. Therefore this guide intentionally does not provide a fake command, transport, environment-variable list, or unverified JSON configuration.
 
 ## Verification
 
-When Cline support is finalized, this guide should document:
+When Cline support is implemented and tested, this guide should document:
 
-1. The exact server command.
-2. The supported MCP transport.
-3. The required Cline configuration.
+1. The exact executable or command.
+2. The required transport.
+3. The exact Cline configuration.
 4. Required environment variables.
-5. A verified tool or resource invocation.
+5. A verified Meshery resource or tool invocation.
 6. Expected output.
 
 ## Troubleshooting
 
-For the current development foundation:
+For the current development server:
 
-- Verify that Go is installed with `go version`.
-- Run the server from the repository root.
-- Verify that `go run cmd/server/main.go` starts successfully.
-- Verify the development ping request and response.
-- Check server output for errors.
+- Verify Go with `go version`.
+- Run `make build`.
+- Run `make run`.
+- Check **stderr** for server errors.
+- Keep stdout reserved for the server's protocol/data output.
+- Verify Meshery configuration separately using the [Configuration Guide](../configuration.md).
 
 ## Related Documentation
 

--- a/docs/integrations/cline.md
+++ b/docs/integrations/cline.md
@@ -2,54 +2,73 @@
 
 > **Status:** Meshery MCP Server is currently under active development.
 
-This guide will document how to connect Cline to Meshery MCP Server once the server command, transport, and Cline configuration have been finalized and tested.
+The current Meshery MCP Server implementation provides a development stdio foundation. A complete, verified Cline integration is not yet documented because the final MCP protocol support and client configuration are still under development.
+
+## Current Status
+
+The current development server can be started with:
+
+    go run cmd/server/main.go
+
+The current foundation reads JSON from standard input and writes JSON to standard output.
+
+The current development ping request is:
+
+    {"method":"ping"}
+
+Expected response:
+
+    {"result":"pong"}
+
+This development interface should not be treated as the final Cline MCP integration.
 
 ## Prerequisites
 
-- VS Code with Cline installed.
-- A running Meshery instance.
-- A working Meshery MCP Server installation.
+- VS Code with Cline installed
+- A working Go development environment
+- A running Meshery instance when testing Meshery integration
+- A local checkout of Meshery MCP Server
 
-## MCP Configuration
+See the [Installation Guide](../installation.md).
 
-Cline supports connecting external MCP servers through its MCP configuration.
+## Configuration
 
-The final Meshery MCP Server configuration will be added here after the implementation is finalized.
-
-Expected configuration concept:
-
-    {
-      "mcpServers": {
-        "meshery": {
-          "command": "<meshery-mcp-server-command>",
-          "args": []
-        }
-      }
-    }
-
-Replace the placeholder command with the actual Meshery MCP Server command.
-
-## Meshery Configuration
-
-Configure the Meshery connection according to the [Configuration Guide](../configuration.md).
+Meshery connection and authentication settings are documented in the [Configuration Guide](../configuration.md).
 
 Never commit real credentials.
 
-## Verify the Connection
+## Cline Integration
 
-After configuring Cline:
+A verified Cline configuration will be documented after the server's MCP protocol support and supported transport are finalized.
 
-1. Restart or reload the client if required.
-2. Open the MCP server/tool interface.
-3. Confirm that Meshery MCP Server is available.
-4. Test an available Meshery MCP tool.
+At the current development stage, this repository does not provide a production-ready Cline configuration command or configuration snippet.
+
+Do not use an unverified placeholder configuration as a production setup.
+
+## Verification
+
+When Cline support is finalized, this guide should document:
+
+1. The exact server command.
+2. The supported MCP transport.
+3. The required Cline configuration.
+4. Required environment variables.
+5. A verified tool or resource invocation.
+6. Expected output.
 
 ## Troubleshooting
 
-If Cline cannot connect:
+For the current development foundation:
 
-- Verify the configured command.
-- Check the Meshery server URL.
-- Verify authentication.
-- Check the MCP server logs.
-- Confirm that the configuration format matches your installed Cline version.
+- Verify that Go is installed with `go version`.
+- Run the server from the repository root.
+- Verify that `go run cmd/server/main.go` starts successfully.
+- Verify the development ping request and response.
+- Check server output for errors.
+
+## Related Documentation
+
+- [Installation](../installation.md)
+- [Configuration](../configuration.md)
+- [Tools and Resources Reference](../tools-reference.md)
+- [Development Guide](../development.md)

--- a/docs/integrations/cline.md
+++ b/docs/integrations/cline.md
@@ -1,0 +1,55 @@
+# Cline Integration
+
+> **Status:** Meshery MCP Server is currently under active development.
+
+This guide will document how to connect Cline to Meshery MCP Server once the server command, transport, and Cline configuration have been finalized and tested.
+
+## Prerequisites
+
+- VS Code with Cline installed.
+- A running Meshery instance.
+- A working Meshery MCP Server installation.
+
+## MCP Configuration
+
+Cline supports connecting external MCP servers through its MCP configuration.
+
+The final Meshery MCP Server configuration will be added here after the implementation is finalized.
+
+Expected configuration concept:
+
+    {
+      "mcpServers": {
+        "meshery": {
+          "command": "<meshery-mcp-server-command>",
+          "args": []
+        }
+      }
+    }
+
+Replace the placeholder command with the actual Meshery MCP Server command.
+
+## Meshery Configuration
+
+Configure the Meshery connection according to the [Configuration Guide](../configuration.md).
+
+Never commit real credentials.
+
+## Verify the Connection
+
+After configuring Cline:
+
+1. Restart or reload the client if required.
+2. Open the MCP server/tool interface.
+3. Confirm that Meshery MCP Server is available.
+4. Test an available Meshery MCP tool.
+
+## Troubleshooting
+
+If Cline cannot connect:
+
+- Verify the configured command.
+- Check the Meshery server URL.
+- Verify authentication.
+- Check the MCP server logs.
+- Confirm that the configuration format matches your installed Cline version.

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,0 +1,55 @@
+# Cursor Integration
+
+> **Status:** Meshery MCP Server is currently under active development.
+
+This guide will document how to connect Cursor to Meshery MCP Server once the server command, transport, and supported Cursor configuration have been finalized and tested.
+
+## Prerequisites
+
+- Cursor
+- A running Meshery instance
+- A working Meshery MCP Server installation
+
+## MCP Configuration
+
+Cursor provides MCP server configuration for connecting external MCP servers.
+
+The final Meshery configuration will be documented here after the implementation is finalized.
+
+Expected configuration concept:
+
+    {
+      "mcpServers": {
+        "meshery": {
+          "command": "<meshery-mcp-server-command>",
+          "args": []
+        }
+      }
+    }
+
+Replace the placeholder command with the actual Meshery MCP Server command.
+
+## Meshery Configuration
+
+Configure the Meshery connection according to the [Configuration Guide](../configuration.md).
+
+Never commit real credentials.
+
+## Verify the Connection
+
+After adding the server:
+
+1. Restart Cursor if required.
+2. Open the MCP tools interface.
+3. Confirm that Meshery MCP Server is available.
+4. Test an available Meshery MCP tool.
+
+## Troubleshooting
+
+If the connection fails:
+
+- Verify the server command.
+- Verify the Meshery server URL.
+- Verify authentication.
+- Check the MCP server logs.
+- Confirm the configuration format supported by your Cursor version.

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -32,9 +32,23 @@ Never commit real API tokens.
 
 ## Cursor Support
 
-A complete, tested Cursor configuration requires a verified MCP protocol request/response flow and client configuration.
+Cursor integration is currently deferred.
 
-Those details are not established by the current implementation evidence reviewed for this documentation. Therefore this guide intentionally does not provide a fake command, transport, environment-variable list, or unverified JSON configuration.
+The repository provides a development stdio server through:
+
+    make run
+
+However, a tested Cursor configuration, required environment-variable set, and verified Cursor MCP request/response flow have not been established in the current repository implementation and CI.
+
+Therefore, this documentation does not provide an unverified Cursor configuration.
+
+The Cursor integration acceptance criterion remains deferred until the following are verified:
+
+1. Exact stdio transport configuration.
+2. Exact Cursor MCP configuration.
+3. Required environment variables.
+4. Successful server startup from Cursor.
+5. A verified MCP request/response or resource/tool invocation.
 
 ## Verification
 

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -1,70 +1,61 @@
 # Cursor Integration
 
-> **Status:** Meshery MCP Server is currently under active development.
+> **Status:** Cursor integration is not yet verified for the current development implementation.
 
-The current Meshery MCP Server implementation provides a development stdio foundation. A complete, verified Cursor integration is not yet documented because the final MCP protocol support and client configuration are still under development.
+The repository currently provides a Go-based development server with stdio support. A tested Cursor configuration was not established from the implementation and CI reviewed for this documentation.
 
-## Current Status
+## Current Development Server
 
-The current development server can be started with:
+The repository entrypoint is:
 
-    go run cmd/server/main.go
+    cmd/meshery-mcp-server/main.go
 
-The current foundation reads JSON from standard input and writes JSON to standard output.
+Run it through:
 
-The current development ping request is:
+    make run
 
-    {"method":"ping"}
-
-Expected response:
-
-    {"result":"pong"}
-
-This development interface should not be treated as the final Cursor MCP integration.
+Do not use an unverified Cursor configuration as a production setup.
 
 ## Prerequisites
 
 - Cursor
-- A working Go development environment
+- Meshery MCP Server built from this repository
 - A running Meshery instance when testing Meshery integration
-- A local checkout of Meshery MCP Server
 
 See the [Installation Guide](../installation.md).
 
 ## Configuration
 
-Meshery connection and authentication settings are documented in the [Configuration Guide](../configuration.md).
+Configure Meshery connection and authentication according to the [Configuration Guide](../configuration.md).
 
-Never commit real credentials.
+Never commit real API tokens.
 
-## Cursor Integration
+## Cursor Support
 
-A verified Cursor configuration will be documented after the server's MCP protocol support and supported transport are finalized.
+A complete, tested Cursor configuration requires a verified MCP protocol request/response flow and client configuration.
 
-At the current development stage, this repository does not provide a production-ready Cursor configuration command or configuration snippet.
-
-Do not use an unverified placeholder configuration as a production setup.
+Those details are not established by the current implementation evidence reviewed for this documentation. Therefore this guide intentionally does not provide a fake command, transport, environment-variable list, or unverified JSON configuration.
 
 ## Verification
 
-When Cursor support is finalized, this guide should document:
+When Cursor support is implemented and tested, this guide should document:
 
-1. The exact server command.
-2. The supported MCP transport.
-3. The required Cursor configuration.
+1. The exact executable or command.
+2. The required transport.
+3. The exact Cursor configuration.
 4. Required environment variables.
-5. A verified tool or resource invocation.
+5. A verified Meshery resource or tool invocation.
 6. Expected output.
 
 ## Troubleshooting
 
-For the current development foundation:
+For the current development server:
 
-- Verify that Go is installed with `go version`.
-- Run the server from the repository root.
-- Verify that `go run cmd/server/main.go` starts successfully.
-- Verify the development ping request and response.
-- Check server output for errors.
+- Verify Go with `go version`.
+- Run `make build`.
+- Run `make run`.
+- Check stderr for server errors.
+- Verify Meshery configuration separately using the [Configuration Guide](../configuration.md).
 
 ## Related Documentation
 

--- a/docs/integrations/cursor.md
+++ b/docs/integrations/cursor.md
@@ -2,54 +2,73 @@
 
 > **Status:** Meshery MCP Server is currently under active development.
 
-This guide will document how to connect Cursor to Meshery MCP Server once the server command, transport, and supported Cursor configuration have been finalized and tested.
+The current Meshery MCP Server implementation provides a development stdio foundation. A complete, verified Cursor integration is not yet documented because the final MCP protocol support and client configuration are still under development.
+
+## Current Status
+
+The current development server can be started with:
+
+    go run cmd/server/main.go
+
+The current foundation reads JSON from standard input and writes JSON to standard output.
+
+The current development ping request is:
+
+    {"method":"ping"}
+
+Expected response:
+
+    {"result":"pong"}
+
+This development interface should not be treated as the final Cursor MCP integration.
 
 ## Prerequisites
 
 - Cursor
-- A running Meshery instance
-- A working Meshery MCP Server installation
+- A working Go development environment
+- A running Meshery instance when testing Meshery integration
+- A local checkout of Meshery MCP Server
 
-## MCP Configuration
+See the [Installation Guide](../installation.md).
 
-Cursor provides MCP server configuration for connecting external MCP servers.
+## Configuration
 
-The final Meshery configuration will be documented here after the implementation is finalized.
-
-Expected configuration concept:
-
-    {
-      "mcpServers": {
-        "meshery": {
-          "command": "<meshery-mcp-server-command>",
-          "args": []
-        }
-      }
-    }
-
-Replace the placeholder command with the actual Meshery MCP Server command.
-
-## Meshery Configuration
-
-Configure the Meshery connection according to the [Configuration Guide](../configuration.md).
+Meshery connection and authentication settings are documented in the [Configuration Guide](../configuration.md).
 
 Never commit real credentials.
 
-## Verify the Connection
+## Cursor Integration
 
-After adding the server:
+A verified Cursor configuration will be documented after the server's MCP protocol support and supported transport are finalized.
 
-1. Restart Cursor if required.
-2. Open the MCP tools interface.
-3. Confirm that Meshery MCP Server is available.
-4. Test an available Meshery MCP tool.
+At the current development stage, this repository does not provide a production-ready Cursor configuration command or configuration snippet.
+
+Do not use an unverified placeholder configuration as a production setup.
+
+## Verification
+
+When Cursor support is finalized, this guide should document:
+
+1. The exact server command.
+2. The supported MCP transport.
+3. The required Cursor configuration.
+4. Required environment variables.
+5. A verified tool or resource invocation.
+6. Expected output.
 
 ## Troubleshooting
 
-If the connection fails:
+For the current development foundation:
 
-- Verify the server command.
-- Verify the Meshery server URL.
-- Verify authentication.
-- Check the MCP server logs.
-- Confirm the configuration format supported by your Cursor version.
+- Verify that Go is installed with `go version`.
+- Run the server from the repository root.
+- Verify that `go run cmd/server/main.go` starts successfully.
+- Verify the development ping request and response.
+- Check server output for errors.
+
+## Related Documentation
+
+- [Installation](../installation.md)
+- [Configuration](../configuration.md)
+- [Tools and Resources Reference](../tools-reference.md)
+- [Development Guide](../development.md)

--- a/docs/integrations/vscode-copilot.md
+++ b/docs/integrations/vscode-copilot.md
@@ -1,0 +1,54 @@
+# VS Code / GitHub Copilot Integration
+
+> **Status:** Meshery MCP Server is currently under active development.
+
+This guide will document how to connect Meshery MCP Server to VS Code and GitHub Copilot after the supported MCP configuration is finalized.
+
+## Prerequisites
+
+- A recent VS Code installation with the required MCP/Copilot functionality.
+- GitHub Copilot access where required.
+- A running Meshery instance.
+- A working Meshery MCP Server installation.
+
+## MCP Configuration
+
+The final configuration format depends on the MCP support provided by the VS Code version in use.
+
+The repository will document the verified configuration once the Meshery MCP Server command and transport are finalized.
+
+Expected configuration concept:
+
+    {
+      "servers": {
+        "meshery": {
+          "command": "<meshery-mcp-server-command>",
+          "args": []
+        }
+      }
+    }
+
+Do not copy this placeholder configuration into a production setup until it has been verified against the implementation.
+
+## Meshery Configuration
+
+Configure the Meshery server connection according to the [Configuration Guide](../configuration.md).
+
+## Verify the Connection
+
+After configuring the MCP server:
+
+1. Restart or reload VS Code if required.
+2. Open the MCP/Copilot tools interface.
+3. Confirm that Meshery MCP Server is available.
+4. Invoke an available Meshery tool.
+
+## Troubleshooting
+
+If the server is unavailable:
+
+- Check the configured command.
+- Check the server logs.
+- Verify the Meshery URL.
+- Verify authentication settings.
+- Confirm the MCP configuration format supported by your VS Code version.

--- a/docs/integrations/vscode-copilot.md
+++ b/docs/integrations/vscode-copilot.md
@@ -1,73 +1,62 @@
 # VS Code / GitHub Copilot Integration
 
-> **Status:** Meshery MCP Server is currently under active development.
+> **Status:** VS Code / GitHub Copilot integration is not yet verified for the current development implementation.
 
-The current Meshery MCP Server implementation provides a development stdio foundation. A complete, verified VS Code / GitHub Copilot integration is not yet documented because the final MCP protocol support and client configuration are still under development.
+The repository currently provides a Go-based development server with stdio support. A tested VS Code / GitHub Copilot configuration was not established from the implementation and CI reviewed for this documentation.
 
-## Current Status
+## Current Development Server
 
-The current development server can be started with:
+The repository entrypoint is:
 
-    go run cmd/server/main.go
+    cmd/meshery-mcp-server/main.go
 
-The current foundation reads JSON from standard input and writes JSON to standard output.
+Run it through:
 
-The current development ping request is:
+    make run
 
-    {"method":"ping"}
-
-Expected response:
-
-    {"result":"pong"}
-
-This development interface should not be treated as the final VS Code / GitHub Copilot MCP integration.
+Do not use an unverified VS Code / GitHub Copilot configuration as a production setup.
 
 ## Prerequisites
 
 - VS Code
 - GitHub Copilot access where required
-- A working Go development environment
+- Meshery MCP Server built from this repository
 - A running Meshery instance when testing Meshery integration
-- A local checkout of Meshery MCP Server
 
 See the [Installation Guide](../installation.md).
 
 ## Configuration
 
-Meshery connection and authentication settings are documented in the [Configuration Guide](../configuration.md).
+Configure Meshery connection and authentication according to the [Configuration Guide](../configuration.md).
 
-Never commit real credentials.
+Never commit real API tokens.
 
-## VS Code / GitHub Copilot Integration
+## VS Code / GitHub Copilot Support
 
-A verified VS Code / GitHub Copilot configuration will be documented after the server's MCP protocol support and supported transport are finalized.
+A complete, tested configuration requires a verified MCP protocol request/response flow and client configuration.
 
-At the current development stage, this repository does not provide a production-ready VS Code / GitHub Copilot configuration command or configuration snippet.
-
-Do not use an unverified placeholder configuration as a production setup.
+Those details are not established by the current implementation evidence reviewed for this documentation. Therefore this guide intentionally does not provide a fake command, transport, environment-variable list, or unverified JSON configuration.
 
 ## Verification
 
-When VS Code / GitHub Copilot support is finalized, this guide should document:
+When VS Code / GitHub Copilot support is implemented and tested, this guide should document:
 
-1. The exact server command.
-2. The supported MCP transport.
-3. The required VS Code configuration.
+1. The exact executable or command.
+2. The required transport.
+3. The exact VS Code configuration.
 4. Required environment variables.
-5. A verified tool or resource invocation.
+5. A verified Meshery resource or tool invocation.
 6. Expected output.
 
 ## Troubleshooting
 
-For the current development foundation:
+For the current development server:
 
-- Verify that Go is installed with `go version`.
-- Run the server from the repository root.
-- Verify that `go run cmd/server/main.go` starts successfully.
-- Verify the development ping request and response.
-- Check server output for errors.
-
-For VS Code / GitHub Copilot-specific connection problems, use the final verified client configuration once MCP support is completed.
+- Verify Go with `go version`.
+- Run `make build`.
+- Run `make run`.
+- Check stderr for server errors.
+- Verify Meshery configuration separately using the [Configuration Guide](../configuration.md).
 
 ## Related Documentation
 

--- a/docs/integrations/vscode-copilot.md
+++ b/docs/integrations/vscode-copilot.md
@@ -2,53 +2,76 @@
 
 > **Status:** Meshery MCP Server is currently under active development.
 
-This guide will document how to connect Meshery MCP Server to VS Code and GitHub Copilot after the supported MCP configuration is finalized.
+The current Meshery MCP Server implementation provides a development stdio foundation. A complete, verified VS Code / GitHub Copilot integration is not yet documented because the final MCP protocol support and client configuration are still under development.
+
+## Current Status
+
+The current development server can be started with:
+
+    go run cmd/server/main.go
+
+The current foundation reads JSON from standard input and writes JSON to standard output.
+
+The current development ping request is:
+
+    {"method":"ping"}
+
+Expected response:
+
+    {"result":"pong"}
+
+This development interface should not be treated as the final VS Code / GitHub Copilot MCP integration.
 
 ## Prerequisites
 
-- A recent VS Code installation with the required MCP/Copilot functionality.
-- GitHub Copilot access where required.
-- A running Meshery instance.
-- A working Meshery MCP Server installation.
+- VS Code
+- GitHub Copilot access where required
+- A working Go development environment
+- A running Meshery instance when testing Meshery integration
+- A local checkout of Meshery MCP Server
 
-## MCP Configuration
+See the [Installation Guide](../installation.md).
 
-The final configuration format depends on the MCP support provided by the VS Code version in use.
+## Configuration
 
-The repository will document the verified configuration once the Meshery MCP Server command and transport are finalized.
+Meshery connection and authentication settings are documented in the [Configuration Guide](../configuration.md).
 
-Expected configuration concept:
+Never commit real credentials.
 
-    {
-      "servers": {
-        "meshery": {
-          "command": "<meshery-mcp-server-command>",
-          "args": []
-        }
-      }
-    }
+## VS Code / GitHub Copilot Integration
 
-Do not copy this placeholder configuration into a production setup until it has been verified against the implementation.
+A verified VS Code / GitHub Copilot configuration will be documented after the server's MCP protocol support and supported transport are finalized.
 
-## Meshery Configuration
+At the current development stage, this repository does not provide a production-ready VS Code / GitHub Copilot configuration command or configuration snippet.
 
-Configure the Meshery server connection according to the [Configuration Guide](../configuration.md).
+Do not use an unverified placeholder configuration as a production setup.
 
-## Verify the Connection
+## Verification
 
-After configuring the MCP server:
+When VS Code / GitHub Copilot support is finalized, this guide should document:
 
-1. Restart or reload VS Code if required.
-2. Open the MCP/Copilot tools interface.
-3. Confirm that Meshery MCP Server is available.
-4. Invoke an available Meshery tool.
+1. The exact server command.
+2. The supported MCP transport.
+3. The required VS Code configuration.
+4. Required environment variables.
+5. A verified tool or resource invocation.
+6. Expected output.
 
 ## Troubleshooting
 
-If the server is unavailable:
+For the current development foundation:
 
-- Check the configured command.
-- Check the server logs.
-- Verify the Meshery URL.
-- Verify authentication settings.
-- Confirm the MCP configuration format supported by your VS Code version.
+- Verify that Go is installed with `go version`.
+- Run the server from the repository root.
+- Verify that `go run cmd/server/main.go` starts successfully.
+- Verify the development ping request and response.
+- Check server output for errors.
+
+For VS Code / GitHub Copilot-specific connection problems, use the final verified client configuration once MCP support is completed.
+
+## Related Documentation
+
+- [Installation](../installation.md)
+- [Configuration](../configuration.md)
+- [Tools and Resources Reference](../tools-reference.md)
+- [Development Guide](../development.md)

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,78 +1,263 @@
-# MCP Tools Reference
+# MCP Resources and Tools Reference
 
-> **Status:** The MCP tool set is currently under active development.
+> **Status:** Meshery MCP Server is currently under active development.
 
-This document is the reference for tools exposed by Meshery MCP Server.
+This document describes the MCP resources currently present in the development implementation.
 
-Tool names, inputs, outputs, and examples must be kept synchronized with the server implementation.
+## MCP Resources
 
-## Tool Documentation Format
+The current resource implementation exposes the following resource URIs:
 
-Each tool should document:
+| Resource URI | Purpose |
+| --- | --- |
+| `meshery://connections` | Returns Meshery connection information |
+| `meshery://providers` | Returns Meshery provider information |
+| `meshery://adapters` | Returns Meshery adapter information |
+| `meshery://health` | Returns server health information |
+| `meshery://environments` | Returns Meshery environment information |
+
+These resources are registered by the resource implementation and are read by URI.
+
+Unsupported resource URIs return an `ErrInvalidURI` error.
+
+## `meshery://connections`
+
+Returns connection information.
+
+### Response
+
+The response contains:
+
+- `timestamp` — time at which the resource was read.
+- `connections` — list of connections.
+
+Each connection contains:
 
 | Field | Description |
 | --- | --- |
-| Tool | MCP tool name |
-| Purpose | What the tool does |
-| Inputs | Required and optional arguments |
-| Output | Returned data |
-| Errors | Expected error conditions |
-| Example | Working usage example |
+| `id` | Connection identifier |
+| `name` | Connection name |
+| `type` | Connection type |
+| `status` | Connection status |
 
-## Planned Tool Areas
+### Current Development Response
 
-The project is expected to expose Meshery capabilities through MCP tools in areas including:
+The current implementation returns sample development data containing a Kubernetes connection named `local-cluster`.
 
-- Designs
-- Connections
-- Environments
-- Workspaces
-- Models
-- Performance capabilities
+Example:
 
-The exact registered tool names and schemas will be added here after they are implemented and tested.
+    {
+      "timestamp": "2026-08-16T00:00:00Z",
+      "connections": [
+        {
+          "id": "1",
+          "name": "local-cluster",
+          "type": "kubernetes",
+          "status": "connected"
+        }
+      ]
+    }
 
-## Designs
+The timestamp is generated when the resource is read.
 
-Design-related tools will allow MCP clients to work with Meshery designs/patterns.
+## `meshery://providers`
 
-The final documentation should include:
+Returns Meshery provider information.
+
+### Response
+
+The response contains:
+
+- `timestamp` — time at which the resource was read.
+- `providers` — list of providers.
+
+Each provider contains:
+
+| Field | Description |
+| --- | --- |
+| `name` | Provider name |
+| `status` | Provider status |
+| `url` | Provider URL |
+
+### Current Development Response
+
+The current implementation returns sample data for the `Meshery` provider.
+
+Example:
+
+    {
+      "timestamp": "2026-08-16T00:00:00Z",
+      "providers": [
+        {
+          "name": "Meshery",
+          "status": "active",
+          "url": "http://localhost"
+        }
+      ]
+    }
+
+The timestamp is generated when the resource is read.
+
+## `meshery://adapters`
+
+Returns Meshery adapter information.
+
+### Response
+
+The response contains:
+
+- `timestamp` — time at which the resource was read.
+- `adapters` — list of adapters.
+
+Each adapter contains:
+
+| Field | Description |
+| --- | --- |
+| `name` | Adapter name |
+| `version` | Adapter version |
+| `status` | Adapter status |
+
+### Current Development Response
+
+The current implementation returns sample data for Istio and Linkerd.
+
+Example:
+
+    {
+      "timestamp": "2026-08-16T00:00:00Z",
+      "adapters": [
+        {
+          "name": "Istio",
+          "version": "1.18",
+          "status": "running"
+        },
+        {
+          "name": "Linkerd",
+          "version": "2.13",
+          "status": "stopped"
+        }
+      ]
+    }
+
+The timestamp is generated when the resource is read.
+
+## `meshery://health`
+
+Returns health information for the development server.
+
+### Response
+
+The response contains:
+
+- `timestamp` — time at which the resource was read.
+- `status` — overall health status.
+- `components` — health status of individual components.
+
+Example:
+
+    {
+      "timestamp": "2026-08-16T00:00:00Z",
+      "status": "healthy",
+      "components": {
+        "server": "ok",
+        "database": "ok",
+        "adapters": "ok"
+      }
+    }
+
+The timestamp is generated when the resource is read.
+
+## `meshery://environments`
+
+Returns Meshery environment information.
+
+### Response
+
+The response contains:
+
+- `timestamp` — time at which the resource was read.
+- `environments` — list of environments.
+
+Each environment contains:
+
+| Field | Description |
+| --- | --- |
+| `id` | Environment identifier |
+| `name` | Environment name |
+| `connections` | List of connection identifiers associated with the environment |
+
+### Current Development Response
+
+The current implementation returns sample `development` and `production` environments.
+
+Example:
+
+    {
+      "timestamp": "2026-08-16T00:00:00Z",
+      "environments": [
+        {
+          "id": "env-1",
+          "name": "development",
+          "connections": ["conn-1"]
+        },
+        {
+          "id": "env-2",
+          "name": "production",
+          "connections": ["conn-2"]
+        }
+      ]
+    }
+
+The timestamp is generated when the resource is read.
+
+## Reading Resources
+
+Resources are selected using their URI.
+
+Supported URIs:
+
+    meshery://connections
+    meshery://providers
+    meshery://adapters
+    meshery://health
+    meshery://environments
+
+The resource router dispatches each supported URI to its corresponding handler.
+
+An unsupported URI returns an invalid-resource-URI error.
+
+## MCP Tools
+
+The MCP tool surface is still under active development.
+
+The resources documented above are implemented as resource handlers and should not be described as MCP tools.
+
+As MCP tools are implemented, this section should be expanded with:
 
 - Tool name
-- Input parameters
-- Pagination behavior
-- Returned design fields
+- Purpose
+- Input schema
+- Output schema
 - Error behavior
-- Working example
+- Examples
+- Corresponding tests
 
-## Connections
+## Current Limitations
 
-Connection-related tools will document how an MCP client can inspect or manage Meshery connections when the corresponding tools are implemented.
+The resource handlers in the current development implementation return sample/static data.
 
-## Environments
+They should therefore be treated as development functionality rather than a complete representation of live Meshery state.
 
-Environment-related tools will document the available environment operations after implementation.
-
-## Workspaces
-
-Workspace-related tools will document the available workspace operations after implementation.
-
-## Models
-
-Model-related tools will document access to the Meshery model/component registry after implementation.
-
-## Performance
-
-Performance-related tools will document supported performance-test operations after implementation.
+As the implementation evolves to retrieve live data through the Meshery API client, this documentation should be updated to describe the actual API-backed behavior.
 
 ## Keeping This Reference Up to Date
 
-Whenever an MCP tool is added or changed:
+When a resource or tool changes:
 
 1. Update this document.
-2. Document every input.
-3. Document the output.
-4. Document expected errors.
-5. Add a working example.
-6. Verify the example against the implementation.
-7. Add or update the corresponding tests.
+2. Document the exact URI or tool name.
+3. Document request/input fields.
+4. Document response/output fields.
+5. Document errors.
+6. Add a working example where applicable.
+7. Keep the documentation synchronized with tests and implementation.

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -6,7 +6,7 @@ This document describes the MCP resources currently present in the development i
 
 ## MCP Resources
 
-The current resource implementation exposes the following resource URIs:
+The current resource implementation exposes:
 
 | Resource URI | Purpose |
 | --- | --- |
@@ -16,9 +16,7 @@ The current resource implementation exposes the following resource URIs:
 | `meshery://health` | Returns server health information |
 | `meshery://environments` | Returns Meshery environment information |
 
-These resources are registered by the resource implementation and are read by URI.
-
-Unsupported resource URIs return an `ErrInvalidURI` error.
+Unsupported resource URIs return the implementation's `ErrInvalidURI` error.
 
 ## `meshery://connections`
 
@@ -42,7 +40,7 @@ Each connection contains:
 
 ### Current Development Response
 
-The current implementation returns sample development data containing a Kubernetes connection named `local-cluster`.
+The current implementation returns sample development data containing a Kubernetes connection.
 
 Example:
 
@@ -50,8 +48,14 @@ Example:
       "timestamp": "2026-08-16T00:00:00Z",
       "connections": [
         {
-          "id": "1",
+          "id": "conn-1",
           "name": "local-cluster",
+          "type": "kubernetes",
+          "status": "connected"
+        },
+        {
+          "id": "conn-2",
+          "name": "production-cluster",
           "type": "kubernetes",
           "status": "connected"
         }
@@ -63,25 +67,6 @@ The timestamp is generated when the resource is read.
 ## `meshery://providers`
 
 Returns Meshery provider information.
-
-### Response
-
-The response contains:
-
-- `timestamp` — time at which the resource was read.
-- `providers` — list of providers.
-
-Each provider contains:
-
-| Field | Description |
-| --- | --- |
-| `name` | Provider name |
-| `status` | Provider status |
-| `url` | Provider URL |
-
-### Current Development Response
-
-The current implementation returns sample data for the `Meshery` provider.
 
 Example:
 
@@ -101,25 +86,6 @@ The timestamp is generated when the resource is read.
 ## `meshery://adapters`
 
 Returns Meshery adapter information.
-
-### Response
-
-The response contains:
-
-- `timestamp` — time at which the resource was read.
-- `adapters` — list of adapters.
-
-Each adapter contains:
-
-| Field | Description |
-| --- | --- |
-| `name` | Adapter name |
-| `version` | Adapter version |
-| `status` | Adapter status |
-
-### Current Development Response
-
-The current implementation returns sample data for Istio and Linkerd.
 
 Example:
 
@@ -143,15 +109,7 @@ The timestamp is generated when the resource is read.
 
 ## `meshery://health`
 
-Returns health information for the development server.
-
-### Response
-
-The response contains:
-
-- `timestamp` — time at which the resource was read.
-- `status` — overall health status.
-- `components` — health status of individual components.
+Returns development server health information.
 
 Example:
 
@@ -171,24 +129,9 @@ The timestamp is generated when the resource is read.
 
 Returns Meshery environment information.
 
-### Response
+Each environment contains an environment ID, name, and connection IDs.
 
-The response contains:
-
-- `timestamp` — time at which the resource was read.
-- `environments` — list of environments.
-
-Each environment contains:
-
-| Field | Description |
-| --- | --- |
-| `id` | Environment identifier |
-| `name` | Environment name |
-| `connections` | List of connection identifiers associated with the environment |
-
-### Current Development Response
-
-The current implementation returns sample `development` and `production` environments.
+The documented connection IDs below correspond to the IDs in the `meshery://connections` example.
 
 Example:
 
@@ -224,13 +167,13 @@ Supported URIs:
 
 The resource router dispatches each supported URI to its corresponding handler.
 
-An unsupported URI returns an invalid-resource-URI error.
+An unsupported URI returns `ErrInvalidURI`.
 
 ## MCP Tools
 
 The MCP tool surface is still under active development.
 
-The resources documented above are implemented as resource handlers and should not be described as MCP tools.
+The resources documented above are resource handlers and should not be described as MCP tools.
 
 As MCP tools are implemented, this section should be expanded with:
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -40,7 +40,9 @@ Each connection contains:
 
 ### Current Development Response
 
-The current implementation returns sample development data containing a Kubernetes connection.
+The current implementation returns static sample development data containing two Kubernetes connections.
+
+This example represents development/sample data only and does not represent live production Meshery state.
 
 Example:
 

--- a/docs/tools-reference.md
+++ b/docs/tools-reference.md
@@ -1,0 +1,78 @@
+# MCP Tools Reference
+
+> **Status:** The MCP tool set is currently under active development.
+
+This document is the reference for tools exposed by Meshery MCP Server.
+
+Tool names, inputs, outputs, and examples must be kept synchronized with the server implementation.
+
+## Tool Documentation Format
+
+Each tool should document:
+
+| Field | Description |
+| --- | --- |
+| Tool | MCP tool name |
+| Purpose | What the tool does |
+| Inputs | Required and optional arguments |
+| Output | Returned data |
+| Errors | Expected error conditions |
+| Example | Working usage example |
+
+## Planned Tool Areas
+
+The project is expected to expose Meshery capabilities through MCP tools in areas including:
+
+- Designs
+- Connections
+- Environments
+- Workspaces
+- Models
+- Performance capabilities
+
+The exact registered tool names and schemas will be added here after they are implemented and tested.
+
+## Designs
+
+Design-related tools will allow MCP clients to work with Meshery designs/patterns.
+
+The final documentation should include:
+
+- Tool name
+- Input parameters
+- Pagination behavior
+- Returned design fields
+- Error behavior
+- Working example
+
+## Connections
+
+Connection-related tools will document how an MCP client can inspect or manage Meshery connections when the corresponding tools are implemented.
+
+## Environments
+
+Environment-related tools will document the available environment operations after implementation.
+
+## Workspaces
+
+Workspace-related tools will document the available workspace operations after implementation.
+
+## Models
+
+Model-related tools will document access to the Meshery model/component registry after implementation.
+
+## Performance
+
+Performance-related tools will document supported performance-test operations after implementation.
+
+## Keeping This Reference Up to Date
+
+Whenever an MCP tool is added or changed:
+
+1. Update this document.
+2. Document every input.
+3. Document the output.
+4. Document expected errors.
+5. Add a working example.
+6. Verify the example against the implementation.
+7. Add or update the corresponding tests.


### PR DESCRIPTION
## Description

This PR addresses #17 by adding the initial documentation structure for Meshery MCP Server.

### Changes

- Updated the README with:
  - Project overview
  - Architecture
  - Project status
  - Meshery resources
  - Community and contribution information
- Added installation documentation.
- Added configuration documentation.
- Added MCP tools reference documentation.
- Added development documentation.
- Added MCP client integration documentation for:
  - Claude Desktop
  - VS Code / GitHub Copilot
  - Cursor
  - Cline

### Notes

The Meshery MCP Server is currently under active development, so implementation-dependent commands and configuration details are clearly marked for completion as the corresponding functionality becomes available.

## Related Issue

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced the legacy README with an overview of the Meshery MCP Server, architecture, status, resources, and contribution guidance.
  * Added installation, configuration, development, and tools reference guides, including five development resource endpoints and sample responses.
  * Added integration guides for Claude Desktop, Cline, Cursor, and VS Code/GitHub Copilot.
  * Documented prerequisites, credential safety, stdio setup, ping verification, troubleshooting, and planned capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->