### PR TITLE
fix: point dependabot at directories that exist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,49 +9,12 @@ updates:
   - pr/dependencies
   - kind/chore
   - language/go
-  ignore:
-  - dependency-name: k8s.io/api
-    versions:
-    - ">= 0.20.a"
-    - "< 0.21"
-  - dependency-name: k8s.io/apimachinery
-    versions:
-    - ">= 0.20.a"
-    - "< 0.21"
-  - dependency-name: k8s.io/client-go
-    versions:
-    - ">= 0.20.a"
-    - "< 0.21"
-- package-ecosystem: npm
-  directory: "/ui"
+
+- package-ecosystem: github-actions
+  directory: "/"
   schedule:
     interval: monthly
   open-pull-requests-limit: 5
   labels:
-  - kind/chore
   - pr/dependencies
-  ignore:
-  - dependency-name: "@material-ui/core"
-    versions:
-    - "> 4.9.13"
-    - "< 5"
-  - dependency-name: next
-    versions:
-    - "> 10.0.1"
-    - "< 10.1"
-  - dependency-name: next-redux-wrapper
-    versions:
-    - ">= 6.a"
-    - "< 7"
-  - dependency-name: react-select
-    versions:
-    - ">= 3.1.a"
-    - "< 3.2"
-- package-ecosystem: npm
-  directory: "/provider-ui"
-  schedule:
-    interval: monthly
-  open-pull-requests-limit: 5
-  labels:
   - kind/chore
-  - pr/dependencies


### PR DESCRIPTION
Every Dependabot run in this repository has failed since it was created, because the config was inherited from meshery/meshery and points at directories this repo does not have.

```
npm_and_yarn in /ui           2026-08-01  failure
npm_and_yarn in /provider-ui  2026-08-01  failure
go_modules in /.              2026-08-01  failure
npm_and_yarn in /ui           2026-07-27  failure
npm_and_yarn in /provider-ui  2026-07-27  failure
go_modules in /.              2026-07-27  failure
```

There is no `ui/` or `provider-ui/` here and there will not be, since this is a Go server, so both npm ecosystems are removed. The gomod entry stays and starts working as soon as a scaffold lands a go.mod at the root.

Also drops the k8s.io version pins, which were carrying meshery/meshery's constraints from the 0.20 era and have nothing to do with this module, and adds github-actions updates so action versions do not drift. That last one is the same class of problem as the golangci-lint-action pin currently on #28.

Deliberately does not touch the workflow files or .goreleaser.yml, since #25 is already working through those.