### PR TITLE
[Tests] add internal/mcpera, a protocol era conformance probe

### DIFF
--- a/cmd/mcpera/main.go
+++ b/cmd/mcpera/main.go
@@ -1,0 +1,58 @@
+// Command mcpera reports which MCP protocol era a server serves.
+//
+//	mcpera ./my-mcp-server
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/meshery-extensions/meshery-mcp-server/internal/mcpera"
+)
+
+func main() {
+	timeout := flag.Duration("timeout", 5*time.Second, "per-probe timeout")
+	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "usage: mcpera [flags] <server> [args...]\n\n")
+		flag.PrintDefaults()
+	}
+	flag.Parse()
+	if flag.NArg() == 0 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	rep, err := mcpera.Probe(context.Background(), *timeout, flag.Arg(0), flag.Args()[1:]...)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mcpera:", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("era: %s\n\n", rep.Era)
+	fmt.Printf("  initialize          %s\n", yesNo(rep.AnswersInitialize, rep.NegotiatedVersion))
+	fmt.Printf("  server/discover     %s\n", yesNo(rep.AnswersDiscover, rep.DiscoverError))
+	fmt.Printf("  modern request      %s\n", yesNo(rep.ServesModernCall, ""))
+	fmt.Printf("  modern result shape %s\n", yesNo(rep.ModernResultIsModern, ""))
+	fmt.Println()
+	for _, n := range rep.Notes {
+		fmt.Printf("  %s\n", n)
+	}
+
+	if rep.SilentDowngrade {
+		os.Exit(1)
+	}
+}
+
+func yesNo(ok bool, detail string) string {
+	s := "no"
+	if ok {
+		s = "yes"
+	}
+	if detail != "" {
+		s += "  (" + detail + ")"
+	}
+	return s
+}

--- a/internal/mcpera/README.md
+++ b/internal/mcpera/README.md
@@ -57,7 +57,7 @@ v1.7.0   {"result":{"_meta":{"io.modelcontextprotocol/serverInfo":{...}},
 v0.58.0 executed the tool for a client it never handshook with, and answered in
 the old shape.
 
-The spec's own mitigation holds up: it tells stdio clients to send
+The spec's own mitigation holds up: it says stdio clients SHOULD send
 `server/discover` first so the mismatch fails deterministically, and on v0.58.0
 that probe does fail cleanly with `-32601`. The hazard is only for a client that
 skips it.
@@ -117,7 +117,7 @@ endpoint directly and needs a server already listening, plus the names of two
 tools it is safe to run.
 
 The rows above are one and two-tool servers, not the SDKs in full. They say what
-these SDKs do on a default setup, which is what an MCP server author gets by
-following each README.
+these SDKs do on a default setup, plus the one documented flag the go-sdk needs
+before it will speak `2026-07-28` over HTTP at all.
 
 

--- a/internal/mcpera/README.md
+++ b/internal/mcpera/README.md
@@ -1,0 +1,123 @@
+# mcpera
+
+Reports which MCP protocol era a server actually serves, by talking to it.
+
+```bash
+go build -o mcpera ./cmd/mcpera
+./mcpera ./my-mcp-server
+```
+
+## Why
+
+Revision `2026-07-28` is the first breaking change to MCP. It removes the
+`initialize` handshake, makes every request carry its own version in `_meta`,
+and adds `server/discover`. That splits the world into a legacy era
+(`2025-11-25` and earlier) and a modern one, and the specification's own
+compatibility table is blunt about the crossing:
+
+> **Modern client, Legacy server.** Fails. The server may reject the request
+> with an implementation-defined error, stay silent, or even process an
+> era-ambiguous method under legacy semantics.
+
+The third outcome is the one worth detecting, because it does not look like a
+failure. A legacy server can answer a modern request by running it and returning
+a legacy-shaped result: no error, no version acknowledgement, nothing on the wire
+saying the eras did not match. The client believes it negotiated `2026-07-28`.
+The server never negotiated anything.
+
+The only signal is the shape of the result. Revision `2026-07-28` puts
+`resultType` on a result and `io.modelcontextprotocol/serverInfo` in its `_meta`;
+the legacy body has neither. A client that reads `content` and stops, which is
+most of them, cannot tell.
+
+## Measured
+
+Four servers, each a one-tool stdio server built against a different SDK, probed
+with a request declaring `protocolVersion: 2026-07-28` and the
+`clientCapabilities` the revision requires:
+
+| server | `initialize` | `server/discover` | modern request | result shape | era |
+|---|---|---|---|---|---|
+| `mark3labs/mcp-go` v0.57.0 | yes | `-32601` | **runs it** | **legacy** | legacy |
+| `mark3labs/mcp-go` v0.58.0 | yes | `-32601` | **runs it** | **legacy** | legacy |
+| `mark3labs/mcp-go` v1.0.0-beta.1 | yes | yes | runs it | modern | dual-era |
+| `modelcontextprotocol/go-sdk` v1.7.0 | yes | yes | runs it | modern | dual-era |
+
+Raw, for the row that matters:
+
+```text
+request  {"method":"tools/call","params":{"name":"ping","arguments":{},
+          "_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28", ...}}}
+
+v0.58.0  {"result":{"content":[{"type":"text","text":"pong"}]}}
+v1.7.0   {"result":{"_meta":{"io.modelcontextprotocol/serverInfo":{...}},
+                    "content":[{"type":"text","text":"pong"}],"resultType":"complete"}}
+```
+
+v0.58.0 executed the tool for a client it never handshook with, and answered in
+the old shape.
+
+The spec's own mitigation holds up: it tells stdio clients to send
+`server/discover` first so the mismatch fails deterministically, and on v0.58.0
+that probe does fail cleanly with `-32601`. The hazard is only for a client that
+skips it.
+
+## Reading the output
+
+`era` is one of `legacy`, `modern`, `dual-era` or `unknown`. Dual-era is the only
+posture that works with every client: a modern client cannot fall back to a
+legacy server, and a legacy client has no fall-forward mechanism at all.
+
+The command exits non-zero when it finds a silent downgrade, so it can gate CI.
+
+## Over HTTP
+
+Streamable HTTP adds a rule with a security rationale behind it. Revision
+`2026-07-28` requires a server to reject a request whose headers disagree with
+its body, with `400` and error `-32020`, and the spec says why:
+
+> This prevents potential security vulnerabilities when different components in
+> the network rely on different sources of truth (e.g., a load balancer routing
+> on the header value while the MCP server executes based on the body value).
+
+`ProbeHTTP` calls a tool twice, once with `Mcp-Name` agreeing with the body and
+once naming a different tool, and reports which happened. Measured against the
+same servers, each exposing a `ping` and a `danger` tool:
+
+| server | serves modern | header/body mismatch |
+|---|---|---|
+| `go-sdk` v1.7.0, `Stateless: true` | yes, modern shape | rejected, `400` / `-32020` |
+| `mcp-go` v1.0.0-beta.1 | yes, modern shape | rejected, `400` / `-32020` |
+| `mcp-go` v0.57.0, legacy session | yes, **legacy shape** | **ran `danger`, `200`** |
+
+Both current SDKs enforce it correctly. v0.57.0 predates the rule, so it ignores
+`Mcp-Name` and runs whatever the body asked for:
+
+```text
+Mcp-Name: ping                      <- what an intermediary would route on
+body:     {"name":"danger"}         <- what the server executed
+->        200 {"content":[{"type":"text","text":"DANGER EXECUTED"}]}
+```
+
+That is not v0.57.0 violating its own revision, since the rule is newer than it.
+It is the deployment shape the spec's own note warns intermediaries about: if the
+`MCP-Protocol-Version` is older than the rule, or absent, an intermediary
+**SHOULD** reject rather than trust header values the server never validated.
+
+One thing worth knowing before reaching for the go-sdk over HTTP: its default
+`NewStreamableHTTPHandler` refuses `2026-07-28` outright with
+`protocol version "2026-07-28" is only supported on stateless HTTP servers`.
+It needs `&mcp.StreamableHTTPOptions{Stateless: true}`, which the README setup
+does not set.
+
+## Scope
+
+The stdio probe opens a fresh process per exchange. The HTTP probe calls the
+endpoint directly and needs a server already listening, plus the names of two
+tools it is safe to run.
+
+The rows above are one and two-tool servers, not the SDKs in full. They say what
+these SDKs do on a default setup, which is what an MCP server author gets by
+following each README.
+
+

--- a/internal/mcpera/classify_internal_test.go
+++ b/internal/mcpera/classify_internal_test.go
@@ -1,0 +1,102 @@
+package mcpera
+
+import "testing"
+
+// TestClassifyReadsBothModernSignalsIndependently is the disagreeing fixture for
+// the era verdict.
+//
+// A server counts as modern either because it answered server/discover or
+// because it served a modern call and returned a modern-shaped result. Both are
+// true of a normal dual-era server, so fixtures built from real servers make the
+// two agree, and either disjunct could be deleted with the suite still green.
+// The revision makes server/discover optional, so the disagreeing cases are not
+// hypothetical: a server may implement one and not the other.
+func TestClassifyReadsBothModernSignalsIndependently(t *testing.T) {
+	for _, tc := range []struct {
+		name              string
+		answersDiscover   bool
+		servesModernCall  bool
+		modernResult      bool
+		answersInitialize bool
+		want              Era
+	}{
+		// Only the discover half is true. server/discover is optional, so a
+		// server may answer it without serving the call this probe made.
+		{"discover alone", true, false, false, false, Modern},
+		// Only the served-call half is true, which is what a server that
+		// declined to implement the optional probe looks like.
+		{"served call alone", false, true, true, false, Modern},
+		// The served call was answered but in the legacy shape, which is not a
+		// modern signal on its own.
+		{"served call, legacy shape", false, true, false, false, Unknown},
+		// Each modern signal alone, alongside the legacy opening, is dual.
+		{"discover alone plus initialize", true, false, false, true, Dual},
+		{"served call alone plus initialize", false, true, true, true, Dual},
+		{"initialize only", false, false, false, true, Legacy},
+		{"nothing", false, false, false, false, Unknown},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Report{
+				AnswersDiscover:      tc.answersDiscover,
+				ServesModernCall:     tc.servesModernCall,
+				ModernResultIsModern: tc.modernResult,
+				AnswersInitialize:    tc.answersInitialize,
+			}
+			r.classify()
+			if r.Era != tc.want {
+				t.Errorf("Era = %v, want %v (discover=%v servedCall=%v modernShape=%v initialize=%v)",
+					r.Era, tc.want, tc.answersDiscover, tc.servesModernCall, tc.modernResult, tc.answersInitialize)
+			}
+		})
+	}
+}
+
+// TestSilentDowngradeNeedsBothHalves pins the other compound verdict. It fires
+// only when a modern call was served and the result came back in the legacy
+// shape, so neither half alone is enough.
+func TestSilentDowngradeNeedsBothHalves(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		served       bool
+		modernResult bool
+		want         bool
+	}{
+		{"served with a legacy-shaped result", true, false, true},
+		{"served with a modern result", true, true, false},
+		{"never served the call", false, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Report{ServesModernCall: tc.served, ModernResultIsModern: tc.modernResult}
+			r.classify()
+			if r.SilentDowngrade != tc.want {
+				t.Errorf("SilentDowngrade = %v, want %v", r.SilentDowngrade, tc.want)
+			}
+		})
+	}
+}
+
+// TestDiscoverNeedsAResultThatDescribesSomething covers the gap between
+// answering a method and implementing it. A server that returns an empty
+// success to server/discover has told a client nothing about itself, and
+// counting that as an answer puts it in the dual-era row, the one a client
+// would trust most.
+func TestDiscoverNeedsAResultThatDescribesSomething(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		result string
+		want   bool
+	}{
+		{"a real discover answer", `{"serverInfo":{"name":"s"},"capabilities":{}}`, true},
+		{"one field is enough", `{"protocolVersions":["2026-07-28"]}`, true},
+		{"empty object", `{}`, false},
+		{"null", `null`, false},
+		{"absent", ``, false},
+		{"not an object", `"ok"`, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := describesAServer([]byte(tc.result)); got != tc.want {
+				t.Errorf("describesAServer(%s) = %v, want %v", tc.result, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/mcpera/classify_internal_test.go
+++ b/internal/mcpera/classify_internal_test.go
@@ -1,6 +1,9 @@
 package mcpera
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // TestClassifyReadsBothModernSignalsIndependently is the disagreeing fixture for
 // the era verdict.
@@ -98,5 +101,47 @@ func TestDiscoverNeedsAResultThatDescribesSomething(t *testing.T) {
 				t.Errorf("describesAServer(%s) = %v, want %v", tc.result, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestSilenceIsNotADeterministicFailure separates the two ways server/discover
+// can fail to succeed. A server that replies with an error has told a client
+// something it can code against. A server that hung or died has told it nothing,
+// and crediting that with a deterministic refusal reports a fact about the
+// method on the strength of a fact about the process.
+func TestSilenceIsNotADeterministicFailure(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		answered   bool
+		errText    string
+		wantInNote string
+	}{
+		{"refused with an error", true, "-32601: method not found", "fails deterministically"},
+		{"answered but described nothing", true, "answered without describing a server", "fails deterministically"},
+		{"hung", false, string(silentTimeout), "says nothing about whether the method is implemented"},
+		{"died", false, string(silentEOF), "says nothing about whether the method is implemented"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Report{DiscoverError: tc.errText, DiscoverAnswered: tc.answered}
+			r.classify()
+			joined := strings.Join(r.Notes, " ")
+			if !strings.Contains(joined, tc.wantInNote) {
+				t.Errorf("notes = %v, want one containing %q", r.Notes, tc.wantInNote)
+			}
+			if !tc.answered && strings.Contains(joined, "fails deterministically") {
+				t.Errorf("silence was reported as a deterministic failure: %v", r.Notes)
+			}
+		})
+	}
+}
+
+// TestDiscoverSuccessAddsNoFailureNote is the control: a server that answered
+// gets neither note.
+func TestDiscoverSuccessAddsNoFailureNote(t *testing.T) {
+	r := &Report{AnswersDiscover: true, AnswersInitialize: true}
+	r.classify()
+	joined := strings.Join(r.Notes, " ")
+	if strings.Contains(joined, "deterministically") || strings.Contains(joined, "no answer") {
+		t.Errorf("a working server should carry no discover failure note: %v", r.Notes)
 	}
 }

--- a/internal/mcpera/classify_internal_test.go
+++ b/internal/mcpera/classify_internal_test.go
@@ -78,19 +78,38 @@ func TestSilentDowngradeNeedsBothHalves(t *testing.T) {
 	}
 }
 
-// TestDiscoverNeedsAResultThatDescribesSomething covers the gap between
-// answering a method and implementing it. A server that returns an empty
-// success to server/discover has told a client nothing about itself, and
-// counting that as an answer puts it in the dual-era row, the one a client
-// would trust most.
-func TestDiscoverNeedsAResultThatDescribesSomething(t *testing.T) {
+// TestDiscoverNeedsARealDiscoverResult covers the gap between answering a
+// method and implementing it.
+//
+// DiscoverResult is what the revision replaced the initialize handshake with,
+// and schema/2026-07-28/schema.json marks supportedVersions, capabilities,
+// resultType, cacheScope and ttlMs required. A server returning anything less
+// has not told a client what to negotiate, and counting it puts that server in
+// the dual-era row, the one a client trusts most.
+func TestDiscoverNeedsARealDiscoverResult(t *testing.T) {
+	const full = `{"supportedVersions":["2026-07-28"],"capabilities":{},` +
+		`"resultType":"complete","cacheScope":"private","ttlMs":60000}`
+
 	for _, tc := range []struct {
 		name   string
 		result string
 		want   bool
 	}{
-		{"a real discover answer", `{"serverInfo":{"name":"s"},"capabilities":{}}`, true},
-		{"one field is enough", `{"protocolVersions":["2026-07-28"]}`, true},
+		{"a real discover answer", full, true},
+		// Every required field present, but the server does not list the version
+		// the probe declared, so there is nothing agreed to speak.
+		{"supports another version only", `{"supportedVersions":["2025-11-25"],"capabilities":{},` +
+			`"resultType":"complete","cacheScope":"private","ttlMs":60000}`, false},
+		{"no supportedVersions", `{"capabilities":{},"resultType":"complete",` +
+			`"cacheScope":"private","ttlMs":60000}`, false},
+		{"no capabilities", `{"supportedVersions":["2026-07-28"],"resultType":"complete",` +
+			`"cacheScope":"private","ttlMs":60000}`, false},
+		{"no ttlMs", `{"supportedVersions":["2026-07-28"],"capabilities":{},` +
+			`"resultType":"complete","cacheScope":"private"}`, false},
+		// ttlMs of zero is a legitimate hint, so its presence is what counts
+		// rather than its value.
+		{"ttlMs of zero still counts", `{"supportedVersions":["2026-07-28"],"capabilities":{},` +
+			`"resultType":"complete","cacheScope":"private","ttlMs":0}`, true},
 		{"empty object", `{}`, false},
 		{"null", `null`, false},
 		{"absent", ``, false},

--- a/internal/mcpera/http.go
+++ b/internal/mcpera/http.go
@@ -3,6 +3,7 @@ package mcpera
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -117,10 +118,17 @@ func ProbeHTTP(ctx context.Context, timeout time.Duration, url, agreeing, mismat
 		// judged the header and no verdict about it is available.
 		rep.note(fmt.Sprintf("Refused the agreeing call too (%s), so this says nothing about header validation; the endpoint did not serve either request.",
 			rep.RefusedModern))
-	case rep.MismatchCode == HeaderMismatchCode:
+	case rep.MismatchCode == HeaderMismatchCode && status == http.StatusBadRequest:
 		rep.ValidatesHeaderBody = true
 		rep.note(fmt.Sprintf("Rejects a header that disagrees with the body, %d with %d, as revision %s requires.",
 			status, HeaderMismatchCode, Version))
+	case rep.MismatchCode == HeaderMismatchCode:
+		// The server caught it, so an intermediary and this server agree about
+		// what ran. The revision requires both the status and the code from a
+		// server, though, and a client keying on the status alone would read
+		// this as a success.
+		rep.note(fmt.Sprintf("Caught the mismatch with %d, but under HTTP %d rather than the 400 revision %s requires alongside it.",
+			HeaderMismatchCode, status, Version))
 	case rep.MismatchCode != 0:
 		// JSON-RPC carries its errors in the body, so an error here is a
 		// rejection whatever the status line says. It is simply not the code
@@ -147,6 +155,43 @@ func ProbeHTTP(ctx context.Context, timeout time.Duration, url, agreeing, mismat
 	return rep, nil
 }
 
+// encodeHeaderValue renders a value for Mcp-Name or Mcp-Param-{Name}.
+//
+// RFC 9110 limits header field values to visible ASCII, space and horizontal
+// tab, and revision 2026-07-28 says a client MUST carry anything outside that
+// set, or with surrounding whitespace, in a Base64 sentinel. A probe that
+// tests conformance has to be conformant itself, or it measures a server
+// against a request the spec does not permit.
+//
+// The markers are lowercase and exact, since servers match on them literally
+// before comparing the decoded value to the body.
+func encodeHeaderValue(v string) string {
+	if headerSafe(v) {
+		return v
+	}
+	return "=?base64?" + base64.StdEncoding.EncodeToString([]byte(v)) + "?="
+}
+
+// headerSafe reports whether a value can travel as a plain header value.
+func headerSafe(v string) bool {
+	if v == "" {
+		return true
+	}
+	if strings.TrimSpace(v) != v {
+		// Leading or trailing whitespace does not survive the wire intact.
+		return false
+	}
+	for _, r := range v {
+		if r == ' ' || r == '\t' {
+			continue
+		}
+		if r < 0x21 || r > 0x7e {
+			return false
+		}
+	}
+	return true
+}
+
 // maxBody bounds a response read. It matches the stdio probe's scanner limit so
 // the two paths agree on what counts as too large to judge.
 const maxBody = 8 << 20
@@ -171,7 +216,7 @@ func callTool(ctx context.Context, c *http.Client, url, headerName, bodyName str
 	req.Header.Set("Accept", "application/json, text/event-stream")
 	req.Header.Set("MCP-Protocol-Version", Version)
 	req.Header.Set("Mcp-Method", "tools/call")
-	req.Header.Set("Mcp-Name", headerName)
+	req.Header.Set("Mcp-Name", encodeHeaderValue(headerName))
 	for k, v := range extra {
 		req.Header.Set(k, v)
 	}

--- a/internal/mcpera/http.go
+++ b/internal/mcpera/http.go
@@ -35,6 +35,11 @@ type HTTPReport struct {
 	// ExecutedMismatched is the hazard: the server ran the tool named in the
 	// body while the header named a different one.
 	ExecutedMismatched bool
+	// BodyTruncated is true when a response was larger than this probe reads.
+	// The verdicts that depend on parsing it are withheld rather than guessed,
+	// because a cut-off body parses as nothing and would otherwise be reported
+	// as the server having answered nonsense.
+	BodyTruncated bool
 
 	Notes []string
 }
@@ -64,7 +69,7 @@ func ProbeHTTP(ctx context.Context, timeout time.Duration, url, agreeing, mismat
 		},
 	}
 
-	status, body, err := callTool(ctx, client, url, agreeing, agreeing, headers)
+	status, body, truncated, err := callTool(ctx, client, url, agreeing, agreeing, headers)
 	if err != nil {
 		return nil, fmt.Errorf("calling %s: %w", agreeing, err)
 	}
@@ -81,6 +86,14 @@ func ProbeHTTP(ctx context.Context, timeout time.Duration, url, agreeing, mismat
 			rep.note(fmt.Sprintf("Refused the agreeing call in the body rather than the status line, JSON-RPC error %d under HTTP 200.", code))
 			break
 		}
+		if truncated {
+			// The call was served; only the shape is unknown, so the result
+			// markers are not judged either way.
+			rep.ServesModern = true
+			rep.BodyTruncated = true
+			rep.note(fmt.Sprintf("Served the agreeing call with a body larger than the %d bytes this probe reads, so the result shape was not judged.", maxBody))
+			break
+		}
 		if jsonPayload(body) == nil {
 			rep.RefusedModern = fmt.Sprintf("200 with a body that is not JSON-RPC: %s", firstLine(body))
 			rep.note("Answered the agreeing call 200 with a body that is not JSON-RPC, so nothing here describes an MCP server.")
@@ -91,7 +104,7 @@ func ProbeHTTP(ctx context.Context, timeout time.Duration, url, agreeing, mismat
 	}
 
 	// The header names one tool, the body names another.
-	status, body, err = callTool(ctx, client, url, mismatched, agreeing, headers)
+	status, body, mismatchTruncated, err := callTool(ctx, client, url, mismatched, agreeing, headers)
 	if err != nil {
 		return nil, fmt.Errorf("calling %s with a mismatched header: %w", agreeing, err)
 	}
@@ -114,6 +127,9 @@ func ProbeHTTP(ctx context.Context, timeout time.Duration, url, agreeing, mismat
 		// the revision specifies.
 		rep.note(fmt.Sprintf("Turned the mismatch away with JSON-RPC error %d (HTTP %d), not the %d the revision specifies.",
 			rep.MismatchCode, status, HeaderMismatchCode))
+	case mismatchTruncated:
+		rep.BodyTruncated = true
+		rep.note(fmt.Sprintf("Answered the mismatched call with a body larger than the %d bytes this probe reads, so whether the tool ran is unknown.", maxBody))
 	case status == http.StatusOK && jsonPayload(body) == nil:
 		// errorCode cannot tell a server that answered without an error from
 		// one whose body it could not read at all, and both arrive here as 0.
@@ -131,7 +147,11 @@ func ProbeHTTP(ctx context.Context, timeout time.Duration, url, agreeing, mismat
 	return rep, nil
 }
 
-func callTool(ctx context.Context, c *http.Client, url, headerName, bodyName string, extra map[string]string) (int, []byte, error) {
+// maxBody bounds a response read. It matches the stdio probe's scanner limit so
+// the two paths agree on what counts as too large to judge.
+const maxBody = 8 << 20
+
+func callTool(ctx context.Context, c *http.Client, url, headerName, bodyName string, extra map[string]string) (int, []byte, bool, error) {
 	payload := map[string]any{
 		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
 		"params": map[string]any{
@@ -141,11 +161,11 @@ func callTool(ctx context.Context, c *http.Client, url, headerName, bodyName str
 	}
 	raw, err := json.Marshal(payload)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, false, err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, false, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json, text/event-stream")
@@ -158,11 +178,18 @@ func callTool(ctx context.Context, c *http.Client, url, headerName, bodyName str
 
 	resp, err := c.Do(req)
 	if err != nil {
-		return 0, nil, err
+		return 0, nil, false, err
 	}
 	defer resp.Body.Close()
-	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
-	return resp.StatusCode, body, err
+	// One byte past the cap, so a body that reached it can be told from one that
+	// merely ended there. A truncated read parses as nothing, and reporting that
+	// as a malformed answer would blame the server for this probe's limit.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxBody+1))
+	truncated := len(body) > maxBody
+	if truncated {
+		body = body[:maxBody]
+	}
+	return resp.StatusCode, body, truncated, err
 }
 
 // jsonPayload pulls the JSON object out of a response, whether it arrived as a

--- a/internal/mcpera/http.go
+++ b/internal/mcpera/http.go
@@ -53,18 +53,41 @@ type HTTPReport struct {
 // so point this at a server whose tools are safe to run.
 func ProbeHTTP(ctx context.Context, timeout time.Duration, url, agreeing, mismatched string, headers map[string]string) (*HTTPReport, error) {
 	rep := &HTTPReport{}
-	client := &http.Client{Timeout: timeout}
+	client := &http.Client{
+		Timeout: timeout,
+		// A redirect is not an answer about protocol eras, and following one
+		// rewrites this POST into a GET against a different URL, so whatever
+		// came back would describe neither the request nor the endpoint asked
+		// about.
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 
 	status, body, err := callTool(ctx, client, url, agreeing, agreeing, headers)
 	if err != nil {
 		return nil, fmt.Errorf("calling %s: %w", agreeing, err)
 	}
 	switch {
-	case status == http.StatusOK:
+	case status != http.StatusOK:
+		rep.RefusedModern = fmt.Sprintf("%d: %s", status, firstLine(body))
+	default:
+		// JSON-RPC carries its errors in the body, so a 200 is not by itself an
+		// acceptance. A server refusing the version answers 200 with an error
+		// object, and scoring that as service would publish it in the
+		// silent-downgrade row: serving the modern era with a legacy result.
+		if code, ok := rpcErrorCode(body); ok {
+			rep.RefusedModern = fmt.Sprintf("200 with JSON-RPC error %d: %s", code, firstLine(body))
+			rep.note(fmt.Sprintf("Refused the agreeing call in the body rather than the status line, JSON-RPC error %d under HTTP 200.", code))
+			break
+		}
+		if jsonPayload(body) == nil {
+			rep.RefusedModern = fmt.Sprintf("200 with a body that is not JSON-RPC: %s", firstLine(body))
+			rep.note("Answered the agreeing call 200 with a body that is not JSON-RPC, so nothing here describes an MCP server.")
+			break
+		}
 		rep.ServesModern = true
 		rep.ModernResultIsModern = resultIsModern(body)
-	default:
-		rep.RefusedModern = fmt.Sprintf("%d: %s", status, firstLine(body))
 	}
 
 	// The header names one tool, the body names another.
@@ -91,6 +114,12 @@ func ProbeHTTP(ctx context.Context, timeout time.Duration, url, agreeing, mismat
 		// the revision specifies.
 		rep.note(fmt.Sprintf("Turned the mismatch away with JSON-RPC error %d (HTTP %d), not the %d the revision specifies.",
 			rep.MismatchCode, status, HeaderMismatchCode))
+	case status == http.StatusOK && jsonPayload(body) == nil:
+		// errorCode cannot tell a server that answered without an error from
+		// one whose body it could not read at all, and both arrive here as 0.
+		// Claiming an execution on the strength of an unreadable body would put
+		// a proxy error page or an SPA fallback in the hazard row.
+		rep.note("Answered the mismatched call 200 with a body that is not JSON-RPC, so whether the tool ran is unknown.")
 	case status == http.StatusOK:
 		rep.ExecutedMismatched = true
 		rep.note("Ran the tool named in the body while the Mcp-Name header named a different one. " +
@@ -169,17 +198,29 @@ func jsonPayload(body []byte) []byte {
 }
 
 func errorCode(body []byte) int {
+	code, _ := rpcErrorCode(body)
+	return code
+}
+
+// rpcErrorCode reports the JSON-RPC error a body carries, and whether it
+// carried one at all.
+//
+// The two are different questions and the code alone cannot separate them: a
+// body with no error, and a body that is not JSON-RPC in the first place, both
+// have no code. Reading a missing code as "the call went through" is what puts
+// a proxy error page in the executed-the-mismatch row.
+func rpcErrorCode(body []byte) (int, bool) {
 	raw := jsonPayload(body)
 	if raw == nil {
-		return 0
+		return 0, false
 	}
 	var r struct {
 		Error *rpcError `json:"error"`
 	}
 	if json.Unmarshal(raw, &r) != nil || r.Error == nil {
-		return 0
+		return 0, false
 	}
-	return r.Error.Code
+	return r.Error.Code, true
 }
 
 func resultIsModern(body []byte) bool {

--- a/internal/mcpera/http.go
+++ b/internal/mcpera/http.go
@@ -173,12 +173,21 @@ func encodeHeaderValue(v string) string {
 }
 
 // headerSafe reports whether a value can travel as a plain header value.
+//
+// A value already shaped like the sentinel is not safe even when it is plain
+// ASCII. The revision requires encoding those too, because a server decodes
+// anything wearing the markers before comparing it to the body, so a tool
+// genuinely named "=?base64?literal?=" would be decoded into something else and
+// the agreeing call would be rejected as a mismatch this probe caused.
 func headerSafe(v string) bool {
 	if v == "" {
 		return true
 	}
 	if strings.TrimSpace(v) != v {
 		// Leading or trailing whitespace does not survive the wire intact.
+		return false
+	}
+	if strings.HasPrefix(v, "=?base64?") && strings.HasSuffix(v, "?=") {
 		return false
 	}
 	for _, r := range v {

--- a/internal/mcpera/http.go
+++ b/internal/mcpera/http.go
@@ -1,0 +1,181 @@
+package mcpera
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// HeaderMismatchCode is the JSON-RPC error revision 2026-07-28 reserves for a
+// request whose headers disagree with its body, or which is missing a required
+// header.
+const HeaderMismatchCode = -32020
+
+// HTTPReport is what an HTTP probe found.
+type HTTPReport struct {
+	// ServesModern is true when a request declaring the modern version was
+	// accepted rather than refused.
+	ServesModern bool
+	// ModernResultIsModern is true when that result carried the modern markers.
+	ModernResultIsModern bool
+	// RefusedModern carries why a modern request was turned away, when it was.
+	RefusedModern string
+
+	// ValidatesHeaderBody is true when a request whose Mcp-Name header disagrees
+	// with the tool named in its body is rejected.
+	ValidatesHeaderBody bool
+	// MismatchStatus and MismatchCode are what that rejection looked like.
+	MismatchStatus int
+	MismatchCode   int
+	// ExecutedMismatched is the hazard: the server ran the tool named in the
+	// body while the header named a different one.
+	ExecutedMismatched bool
+
+	Notes []string
+}
+
+// ProbeHTTP sends a tool call to an MCP endpoint twice, once with the headers
+// agreeing with the body and once with the Mcp-Name header naming a different
+// tool, and reports whether the disagreement was caught.
+//
+// Revision 2026-07-28 requires servers to reject a header that disagrees with
+// the body, and says why: an intermediary may route on the header while the
+// server executes the body. A server predating the rule ignores the header and
+// runs whatever the body asked for, so the two sources of truth diverge without
+// anything on the wire saying so.
+//
+// agreeing and mismatched name two tools the server exposes. Both are called,
+// so point this at a server whose tools are safe to run.
+func ProbeHTTP(ctx context.Context, timeout time.Duration, url, agreeing, mismatched string, headers map[string]string) (*HTTPReport, error) {
+	rep := &HTTPReport{}
+	client := &http.Client{Timeout: timeout}
+
+	status, body, err := callTool(ctx, client, url, agreeing, agreeing, headers)
+	if err != nil {
+		return nil, fmt.Errorf("calling %s: %w", agreeing, err)
+	}
+	switch {
+	case status == http.StatusOK:
+		rep.ServesModern = true
+		rep.ModernResultIsModern = resultIsModern(body)
+	default:
+		rep.RefusedModern = fmt.Sprintf("%d: %s", status, firstLine(body))
+	}
+
+	// The header names one tool, the body names another.
+	status, body, err = callTool(ctx, client, url, mismatched, agreeing, headers)
+	if err != nil {
+		return nil, fmt.Errorf("calling %s with a mismatched header: %w", agreeing, err)
+	}
+	rep.MismatchStatus = status
+	rep.MismatchCode = errorCode(body)
+
+	switch {
+	case rep.MismatchCode == HeaderMismatchCode:
+		rep.ValidatesHeaderBody = true
+		rep.note(fmt.Sprintf("Rejects a header that disagrees with the body, %d with %d, as revision %s requires.",
+			status, HeaderMismatchCode, Version))
+	case status == http.StatusOK:
+		rep.ExecutedMismatched = true
+		rep.note("Ran the tool named in the body while the Mcp-Name header named a different one. " +
+			"An intermediary routing on that header and this server disagree about what just executed.")
+	default:
+		rep.note(fmt.Sprintf("Turned the mismatch away with %d, but not with the %d the revision specifies.",
+			status, HeaderMismatchCode))
+	}
+	return rep, nil
+}
+
+func callTool(ctx context.Context, c *http.Client, url, headerName, bodyName string, extra map[string]string) (int, []byte, error) {
+	payload := map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{
+			"name": bodyName, "arguments": map[string]any{},
+			"_meta": modernMeta(),
+		},
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return 0, nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("MCP-Protocol-Version", Version)
+	req.Header.Set("Mcp-Method", "tools/call")
+	req.Header.Set("Mcp-Name", headerName)
+	for k, v := range extra {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	return resp.StatusCode, body, err
+}
+
+// jsonPayload pulls the JSON object out of a response that may be a bare body
+// or a single SSE event.
+func jsonPayload(body []byte) []byte {
+	for _, line := range strings.Split(string(body), "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimPrefix(line, "data:")
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "{") {
+			return []byte(line)
+		}
+	}
+	return nil
+}
+
+func errorCode(body []byte) int {
+	raw := jsonPayload(body)
+	if raw == nil {
+		return 0
+	}
+	var r struct {
+		Error *rpcError `json:"error"`
+	}
+	if json.Unmarshal(raw, &r) != nil || r.Error == nil {
+		return 0
+	}
+	return r.Error.Code
+}
+
+func resultIsModern(body []byte) bool {
+	raw := jsonPayload(body)
+	if raw == nil {
+		return false
+	}
+	var r struct {
+		Result json.RawMessage `json:"result"`
+	}
+	if json.Unmarshal(raw, &r) != nil || r.Result == nil {
+		return false
+	}
+	return isModernResult(r.Result)
+}
+
+func firstLine(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	if len(s) > 120 {
+		s = s[:120]
+	}
+	return s
+}
+
+func (r *HTTPReport) note(s string) { r.Notes = append(r.Notes, s) }

--- a/internal/mcpera/http.go
+++ b/internal/mcpera/http.go
@@ -76,10 +76,21 @@ func ProbeHTTP(ctx context.Context, timeout time.Duration, url, agreeing, mismat
 	rep.MismatchCode = errorCode(body)
 
 	switch {
+	case !rep.ServesModern:
+		// The endpoint would not serve the agreeing call either, so it never
+		// judged the header and no verdict about it is available.
+		rep.note(fmt.Sprintf("Refused the agreeing call too (%s), so this says nothing about header validation; the endpoint did not serve either request.",
+			rep.RefusedModern))
 	case rep.MismatchCode == HeaderMismatchCode:
 		rep.ValidatesHeaderBody = true
 		rep.note(fmt.Sprintf("Rejects a header that disagrees with the body, %d with %d, as revision %s requires.",
 			status, HeaderMismatchCode, Version))
+	case rep.MismatchCode != 0:
+		// JSON-RPC carries its errors in the body, so an error here is a
+		// rejection whatever the status line says. It is simply not the code
+		// the revision specifies.
+		rep.note(fmt.Sprintf("Turned the mismatch away with JSON-RPC error %d (HTTP %d), not the %d the revision specifies.",
+			rep.MismatchCode, status, HeaderMismatchCode))
 	case status == http.StatusOK:
 		rep.ExecutedMismatched = true
 		rep.note("Ran the tool named in the body while the Mcp-Name header named a different one. " +
@@ -125,16 +136,34 @@ func callTool(ctx context.Context, c *http.Client, url, headerName, bodyName str
 	return resp.StatusCode, body, err
 }
 
-// jsonPayload pulls the JSON object out of a response that may be a bare body
-// or a single SSE event.
+// jsonPayload pulls the JSON object out of a response, whether it arrived as a
+// plain body or as SSE events.
+//
+// The whole body is tried first, because a pretty-printed object spans many
+// lines and taking the first line that opens a brace would return just that
+// brace. Only if that fails are data: lines gathered, which is how an SSE event
+// carries a payload, one event's lines joined.
 func jsonPayload(body []byte) []byte {
+	if trimmed := bytes.TrimSpace(body); json.Valid(trimmed) && len(trimmed) > 0 && trimmed[0] == '{' {
+		return trimmed
+	}
+	var event []string
 	for _, line := range strings.Split(string(body), "\n") {
-		line = strings.TrimSpace(line)
-		line = strings.TrimPrefix(line, "data:")
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "{") {
-			return []byte(line)
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			// Blank line ends an event. Take the first one that parses.
+			if joined := strings.Join(event, ""); json.Valid([]byte(joined)) && strings.HasPrefix(joined, "{") {
+				return []byte(joined)
+			}
+			event = nil
+			continue
 		}
+		if rest, ok := strings.CutPrefix(trimmed, "data:"); ok {
+			event = append(event, strings.TrimSpace(rest))
+		}
+	}
+	if joined := strings.Join(event, ""); json.Valid([]byte(joined)) && strings.HasPrefix(joined, "{") {
+		return []byte(joined)
 	}
 	return nil
 }

--- a/internal/mcpera/http_test.go
+++ b/internal/mcpera/http_test.go
@@ -153,3 +153,78 @@ func TestHTTPRefusalIsReported(t *testing.T) {
 		t.Error("nothing executed")
 	}
 }
+
+// JSON-RPC carries its errors in the body, so a server may reject the mismatch
+// and still answer 200. Reporting that as the dangerous tool having run is a
+// false accusation, and the report is the whole product here.
+func TestMismatchRejectedWithHTTP200IsNotAnExecution(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Header.Get("Mcp-Name") != "ping" {
+			// A rejection that is not the header-mismatch code: still an
+			// error, still a 200, still not an execution.
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32602,"message":"invalid params"}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"resultType":"complete","content":[]}}`))
+	}))
+	defer srv.Close()
+
+	rep, err := mcpera.ProbeHTTP(context.Background(), 5*time.Second, srv.URL, "ping", "danger", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.ExecutedMismatched {
+		t.Error("reported the tool as executed, but the server answered with a JSON-RPC error")
+	}
+	if rep.ValidatesHeaderBody {
+		t.Error("it rejected with -32602, not the code the revision specifies, so this is not conformance")
+	}
+}
+
+// A pretty-printed body is one JSON object across many lines. Reading only the
+// first line starting with { yields a bare brace, which parses as nothing.
+func TestPrettyPrintedBodyIsParsed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Header.Get("Mcp-Name") != "ping" {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"error\": {\n    \"code\": -32020,\n    \"message\": \"header mismatch\"\n  }\n}"))
+			return
+		}
+		_, _ = w.Write([]byte("{\n  \"jsonrpc\": \"2.0\",\n  \"id\": 1,\n  \"result\": {\n    \"resultType\": \"complete\"\n  }\n}"))
+	}))
+	defer srv.Close()
+
+	rep, err := mcpera.ProbeHTTP(context.Background(), 5*time.Second, srv.URL, "ping", "danger", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.ModernResultIsModern {
+		t.Error("a pretty-printed modern result was not recognised as modern")
+	}
+	if rep.MismatchCode != mcpera.HeaderMismatchCode {
+		t.Errorf("mismatch code = %d, want %d from a pretty-printed error body", rep.MismatchCode, mcpera.HeaderMismatchCode)
+	}
+}
+
+// When the endpoint refuses both calls for an unrelated reason, the report must
+// not speak as though the server evaluated the header at all.
+func TestRefusedBothCallsIsNotAMismatchVerdict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "Invalid session ID", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	rep, err := mcpera.ProbeHTTP(context.Background(), 5*time.Second, srv.URL, "ping", "danger", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.ValidatesHeaderBody || rep.ExecutedMismatched {
+		t.Error("the endpoint answered nothing, so neither verdict is available")
+	}
+	joined := strings.Join(rep.Notes, " ")
+	if !strings.Contains(joined, "did not serve") && !strings.Contains(joined, "refused") {
+		t.Errorf("the notes should say the endpoint refused the request, got: %v", rep.Notes)
+	}
+}

--- a/internal/mcpera/http_test.go
+++ b/internal/mcpera/http_test.go
@@ -1,0 +1,155 @@
+package mcpera_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/meshery-extensions/meshery-mcp-server/internal/mcpera"
+)
+
+// fakeHTTP serves tools/call. When validate is true it enforces the header
+// against the body the way revision 2026-07-28 requires; when false it ignores
+// the header and runs whatever the body asked for, which is what a server
+// predating the rule does.
+func fakeHTTP(t *testing.T, validate, modernShape bool) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		var req struct {
+			ID     any `json:"id"`
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		_ = json.Unmarshal(raw, &req)
+
+		w.Header().Set("Content-Type", "application/json")
+		if validate && r.Header.Get("Mcp-Name") != req.Params.Name {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": req.ID,
+				"error": map[string]any{
+					"code": mcpera.HeaderMismatchCode,
+					"message": "header mismatch: Mcp-Name header value '" +
+						r.Header.Get("Mcp-Name") + "' does not match body value '" + req.Params.Name + "'",
+				},
+			})
+			return
+		}
+		result := map[string]any{"content": []any{map[string]any{"type": "text", "text": req.Params.Name}}}
+		if modernShape {
+			result["resultType"] = "complete"
+			result["_meta"] = map[string]any{mcpera.MetaServerInfo: map[string]any{"name": "fake"}}
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"jsonrpc": "2.0", "id": req.ID, "result": result})
+	}))
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// TestHTTPConformantServerPasses covers a server that enforces the rule.
+func TestHTTPConformantServerPasses(t *testing.T) {
+	rep, err := mcpera.ProbeHTTP(context.Background(), 5*time.Second,
+		fakeHTTP(t, true, true), "ping", "danger", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.ValidatesHeaderBody {
+		t.Error("expected the mismatch to be caught")
+	}
+	if rep.MismatchCode != mcpera.HeaderMismatchCode {
+		t.Errorf("code = %d, want %d", rep.MismatchCode, mcpera.HeaderMismatchCode)
+	}
+	if rep.ExecutedMismatched {
+		t.Error("a rejected request did not execute")
+	}
+	if !rep.ServesModern || !rep.ModernResultIsModern {
+		t.Error("expected a modern result on the agreeing call")
+	}
+}
+
+// TestHTTPServerThatIgnoresTheHeader covers the hazard. The server runs the
+// tool the body named while the header named another, so an intermediary
+// routing on that header has a different idea of what happened.
+func TestHTTPServerThatIgnoresTheHeader(t *testing.T) {
+	rep, err := mcpera.ProbeHTTP(context.Background(), 5*time.Second,
+		fakeHTTP(t, false, false), "ping", "danger", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.ValidatesHeaderBody {
+		t.Error("this server does not validate, and should not be reported as doing so")
+	}
+	if !rep.ExecutedMismatched {
+		t.Fatal("running the body's tool under a different header name is the finding")
+	}
+	if rep.ModernResultIsModern {
+		t.Error("a legacy-shaped result should not read as modern")
+	}
+	if !strings.Contains(strings.Join(rep.Notes, " "), "disagree about what just executed") {
+		t.Errorf("the notes should name the consequence: %v", rep.Notes)
+	}
+}
+
+// TestHTTPSSEFramingIsUnderstood checks a response delivered as a single SSE
+// event is read the same as a plain body, since Streamable HTTP may use either.
+func TestHTTPSSEFramingIsUnderstood(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		var req struct {
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		_ = json.Unmarshal(raw, &req)
+		if r.Header.Get("Mcp-Name") != req.Params.Name {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32020,\"message\":\"header mismatch\"}}\n\n"))
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"resultType\":\"complete\",\"content\":[]}}\n\n"))
+	}))
+	defer srv.Close()
+
+	rep, err := mcpera.ProbeHTTP(context.Background(), 5*time.Second, srv.URL, "ping", "danger", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.ValidatesHeaderBody {
+		t.Error("an SSE-framed error should still be read as a rejection")
+	}
+	if !rep.ModernResultIsModern {
+		t.Error("an SSE-framed result should still be read as modern")
+	}
+}
+
+// TestHTTPRefusalIsReported covers a server that turns the modern request away
+// entirely, which is what a stateful legacy endpoint does to a stateless call.
+func TestHTTPRefusalIsReported(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Invalid session ID", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	rep, err := mcpera.ProbeHTTP(context.Background(), 5*time.Second, srv.URL, "ping", "danger", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep.ServesModern {
+		t.Error("a 404 is not serving the modern request")
+	}
+	if !strings.Contains(rep.RefusedModern, "Invalid session ID") {
+		t.Errorf("the refusal should carry the server's reason, got %q", rep.RefusedModern)
+	}
+	if rep.ExecutedMismatched {
+		t.Error("nothing executed")
+	}
+}

--- a/internal/mcpera/mcpera.go
+++ b/internal/mcpera/mcpera.go
@@ -194,21 +194,42 @@ func isModernResult(raw json.RawMessage) bool {
 	return ok
 }
 
-// describesAServer reports whether a server/discover result carries anything.
+// describesAServer reports whether a server/discover result is one.
 //
-// The revision has the method return what a client would otherwise have learned
-// from initialize, so an answer names the server, its capabilities or the
-// versions it speaks. An absent result, a null, or an empty object answers none
-// of that, and a probe cannot call a server dual-era on the strength of it.
+// The revision replaces the initialize handshake with this method, so the
+// answer is what a client negotiates from: DiscoverResult requires
+// supportedVersions, capabilities, resultType, cacheScope and ttlMs
+// (schema/2026-07-28/schema.json). Accepting any non-empty object instead would
+// let a server that merely tolerates the method be published as dual-era, which
+// is the row a client trusts most.
+//
+// supportedVersions is checked for this revision specifically. A server that
+// answers the probe but does not list the version the probe declared has not
+// agreed to speak it, and the list is what the spec tells a client to choose
+// from.
 func describesAServer(result json.RawMessage) bool {
 	if len(result) == 0 {
 		return false
 	}
-	var fields map[string]json.RawMessage
-	if json.Unmarshal(result, &fields) != nil {
+	var r struct {
+		SupportedVersions []string         `json:"supportedVersions"`
+		Capabilities      *json.RawMessage `json:"capabilities"`
+		ResultType        *string          `json:"resultType"`
+		CacheScope        *string          `json:"cacheScope"`
+		TTLMs             *int64           `json:"ttlMs"`
+	}
+	if json.Unmarshal(result, &r) != nil {
 		return false
 	}
-	return len(fields) > 0
+	if r.Capabilities == nil || r.ResultType == nil || r.CacheScope == nil || r.TTLMs == nil {
+		return false
+	}
+	for _, v := range r.SupportedVersions {
+		if v == Version {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Report) classify() {

--- a/internal/mcpera/mcpera.go
+++ b/internal/mcpera/mcpera.go
@@ -67,6 +67,10 @@ type Report struct {
 	AnswersDiscover bool
 	// DiscoverError is what server/discover returned when it did not succeed.
 	DiscoverError string
+	// DiscoverAnswered is true when the server replied to server/discover at
+	// all, even to refuse it. A refusal is a fact about the method; silence is
+	// only a fact about the process, and the two cannot be reported alike.
+	DiscoverAnswered bool
 	// ServesModernCall is true when a modern tools/call ran without an error.
 	ServesModernCall bool
 	// ModernResultIsModern is true when that result carried the markers a
@@ -106,7 +110,7 @@ func modernMeta() map[string]any {
 func Probe(ctx context.Context, timeout time.Duration, name string, args ...string) (*Report, error) {
 	rep := &Report{Era: Unknown}
 
-	init, err := exchange(ctx, timeout, name, args, map[string]any{
+	init, _, err := exchange(ctx, timeout, name, args, map[string]any{
 		"jsonrpc": "2.0", "id": 1, "method": "initialize",
 		"params": map[string]any{
 			"protocolVersion": "2025-11-25",
@@ -127,7 +131,7 @@ func Probe(ctx context.Context, timeout time.Duration, name string, args ...stri
 		}
 	}
 
-	disc, err := exchange(ctx, timeout, name, args, map[string]any{
+	disc, discSilence, err := exchange(ctx, timeout, name, args, map[string]any{
 		"jsonrpc": "2.0", "id": 1, "method": "server/discover",
 		"params": map[string]any{"_meta": modernMeta()},
 	})
@@ -136,9 +140,14 @@ func Probe(ctx context.Context, timeout time.Duration, name string, args ...stri
 	}
 	switch {
 	case disc == nil:
-		rep.DiscoverError = "no response"
+		// Not "it refused". The server said nothing, and why it said nothing is
+		// the difference between a finding about the method and one about the
+		// server being up at all.
+		rep.DiscoverError = string(discSilence)
+		rep.DiscoverAnswered = false
 	case disc.Error != nil:
 		rep.DiscoverError = fmt.Sprintf("%d: %s", disc.Error.Code, disc.Error.Message)
+		rep.DiscoverAnswered = true
 	case !describesAServer(disc.Result):
 		// A reply with no error but nothing in it is not an answer to
 		// server/discover. Counting it as one is how a server that merely
@@ -146,11 +155,12 @@ func Probe(ctx context.Context, timeout time.Duration, name string, args ...stri
 		// client would trust most. The modern tools/list check below already
 		// requires a result; this is the same bar.
 		rep.DiscoverError = "answered without describing a server"
+		rep.DiscoverAnswered = true
 	default:
 		rep.AnswersDiscover = true
 	}
 
-	call, err := exchange(ctx, timeout, name, args, map[string]any{
+	call, _, err := exchange(ctx, timeout, name, args, map[string]any{
 		"jsonrpc": "2.0", "id": 1, "method": "tools/list",
 		"params": map[string]any{"_meta": modernMeta()},
 	})
@@ -225,9 +235,17 @@ func (r *Report) classify() {
 			" and answered in the legacy shape, with no error and no version acknowledgement. " +
 			"A client reading only content cannot tell it was downgraded.")
 	}
-	if !r.AnswersDiscover && r.DiscoverError != "" {
+	switch {
+	case r.AnswersDiscover || r.DiscoverError == "":
+	case r.DiscoverAnswered:
 		r.note("server/discover fails deterministically (" + r.DiscoverError +
 			"), which is the probe the spec tells stdio clients to send first.")
+	default:
+		// Nothing came back, so nothing was learned about the method. Calling
+		// that a deterministic failure would credit the server with a refusal
+		// it never made.
+		r.note("server/discover got no answer (" + r.DiscoverError +
+			"), so this says nothing about whether the method is implemented.")
 	}
 }
 
@@ -235,21 +253,31 @@ func (r *Report) note(s string) { r.Notes = append(r.Notes, s) }
 
 // exchange runs one request against a fresh server process and returns the
 // first response, or nil when the server stayed silent.
-func exchange(ctx context.Context, timeout time.Duration, name string, args []string, req map[string]any) (*rpcResponse, error) {
+// silence explains why a probe got nothing back. The three cases look alike to
+// a caller and mean different things: a server that refused is a finding about
+// the method, and a server that hung or died is a finding about the server.
+type silence string
+
+const (
+	silentTimeout silence = "the server did not answer within the timeout"
+	silentEOF     silence = "the server ended its output without answering"
+)
+
+func exchange(ctx context.Context, timeout time.Duration, name string, args []string, req map[string]any) (*rpcResponse, silence, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, name, args...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if err := cmd.Start(); err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	defer func() {
 		_ = stdin.Close()
@@ -259,10 +287,11 @@ func exchange(ctx context.Context, timeout time.Duration, name string, args []st
 
 	body, err := json.Marshal(req)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if _, err := stdin.Write(append(body, '\n')); err != nil {
-		return nil, nil
+		// The pipe closed under us, which means the process is already gone.
+		return nil, silentEOF, nil
 	}
 
 	type result struct {
@@ -294,10 +323,15 @@ func exchange(ctx context.Context, timeout time.Duration, name string, args []st
 	select {
 	case r := <-done:
 		if r.err != nil && !errors.Is(r.err, context.DeadlineExceeded) {
-			return nil, r.err
+			return nil, "", r.err
 		}
-		return r.resp, nil
+		if r.resp == nil {
+			// The scanner reached the end of the server's output without a
+			// reply, so the process answered nothing and then stopped.
+			return nil, silentEOF, nil
+		}
+		return r.resp, "", nil
 	case <-ctx.Done():
-		return nil, nil // silence is a finding, not an error
+		return nil, silentTimeout, nil // silence is a finding, not an error
 	}
 }

--- a/internal/mcpera/mcpera.go
+++ b/internal/mcpera/mcpera.go
@@ -1,0 +1,279 @@
+// Package mcpera probes an MCP server over stdio and reports which protocol
+// era it actually serves.
+//
+// Protocol revision 2026-07-28 is the first breaking change to MCP. It removes
+// the initialize handshake, makes every request carry its own version in _meta,
+// and adds server/discover. That splits implementations into a legacy era
+// (2025-11-25 and earlier) and a modern one, and the specification's own
+// compatibility table says a modern client against a legacy server "may reject
+// the request with an implementation-defined error, stay silent, or even
+// process an era-ambiguous method under legacy semantics".
+//
+// That last outcome is the one worth detecting. A legacy server can answer a
+// modern request by running it, returning a legacy-shaped result with no error
+// and no version acknowledgement. The client believes it negotiated
+// 2026-07-28; the server never negotiated anything. Nothing in the exchange
+// says so unless the client checks for the modern result markers, and a client
+// that reads only content will not.
+package mcpera
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Version is the protocol revision the modern probes declare.
+const Version = "2026-07-28"
+
+// The well-known _meta keys revision 2026-07-28 defines. protocolVersion and
+// clientCapabilities are required on every modern request.
+const (
+	MetaProtocolVersion    = "io.modelcontextprotocol/protocolVersion"
+	MetaClientInfo         = "io.modelcontextprotocol/clientInfo"
+	MetaClientCapabilities = "io.modelcontextprotocol/clientCapabilities"
+	MetaServerInfo         = "io.modelcontextprotocol/serverInfo"
+)
+
+// Era is the protocol era a server serves.
+type Era string
+
+const (
+	// Legacy answers initialize and does not serve modern requests correctly.
+	Legacy Era = "legacy"
+	// Modern serves modern requests and does not answer initialize.
+	Modern Era = "modern"
+	// Dual answers both, which is the only posture that works with every client.
+	Dual Era = "dual-era"
+	// Unknown covers a server that answered neither opening.
+	Unknown Era = "unknown"
+)
+
+// Report is what a probe found.
+type Report struct {
+	Era Era
+
+	// AnswersInitialize is true when the legacy handshake succeeds.
+	AnswersInitialize bool
+	// NegotiatedVersion is the revision the legacy handshake settled on.
+	NegotiatedVersion string
+	// AnswersDiscover is true when server/discover succeeds. The spec says a
+	// stdio client SHOULD send it first so an era mismatch fails deterministically.
+	AnswersDiscover bool
+	// DiscoverError is what server/discover returned when it did not succeed.
+	DiscoverError string
+	// ServesModernCall is true when a modern tools/call ran without an error.
+	ServesModernCall bool
+	// ModernResultIsModern is true when that result carried the markers a
+	// modern result must have, rather than a legacy-shaped body.
+	ModernResultIsModern bool
+
+	// SilentDowngrade is the hazard: the server ran a modern request and
+	// answered in the legacy shape, so the exchange looks successful to a
+	// client that does not inspect the result markers.
+	SilentDowngrade bool
+
+	Notes []string
+}
+
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type rpcResponse struct {
+	ID     any             `json:"id"`
+	Result json.RawMessage `json:"result"`
+	Error  *rpcError       `json:"error"`
+}
+
+func modernMeta() map[string]any {
+	return map[string]any{
+		MetaProtocolVersion:    Version,
+		MetaClientInfo:         map[string]any{"name": "mcpera", "version": "0"},
+		MetaClientCapabilities: map[string]any{},
+	}
+}
+
+// Probe starts the server, runs each opening against a fresh process, and
+// reports what it found. Each exchange gets its own process because the two
+// eras are mutually exclusive openings and a server may hold session state.
+func Probe(ctx context.Context, timeout time.Duration, name string, args ...string) (*Report, error) {
+	rep := &Report{Era: Unknown}
+
+	init, err := exchange(ctx, timeout, name, args, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-11-25",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "mcpera", "version": "0"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("probing initialize: %w", err)
+	}
+	if init != nil && init.Error == nil && init.Result != nil {
+		rep.AnswersInitialize = true
+		var r struct {
+			ProtocolVersion string `json:"protocolVersion"`
+		}
+		if json.Unmarshal(init.Result, &r) == nil {
+			rep.NegotiatedVersion = r.ProtocolVersion
+		}
+	}
+
+	disc, err := exchange(ctx, timeout, name, args, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "server/discover",
+		"params": map[string]any{"_meta": modernMeta()},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("probing server/discover: %w", err)
+	}
+	switch {
+	case disc == nil:
+		rep.DiscoverError = "no response"
+	case disc.Error != nil:
+		rep.DiscoverError = fmt.Sprintf("%d: %s", disc.Error.Code, disc.Error.Message)
+	default:
+		rep.AnswersDiscover = true
+	}
+
+	call, err := exchange(ctx, timeout, name, args, map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/list",
+		"params": map[string]any{"_meta": modernMeta()},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("probing modern tools/list: %w", err)
+	}
+	if call != nil && call.Error == nil && call.Result != nil {
+		rep.ServesModernCall = true
+		rep.ModernResultIsModern = isModernResult(call.Result)
+	}
+
+	rep.classify()
+	return rep, nil
+}
+
+// isModernResult reports whether a result carries the markers revision
+// 2026-07-28 puts on one. A legacy server answering a modern request returns
+// the old body, which has neither.
+func isModernResult(raw json.RawMessage) bool {
+	var r struct {
+		ResultType string         `json:"resultType"`
+		Meta       map[string]any `json:"_meta"`
+	}
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return false
+	}
+	if r.ResultType != "" {
+		return true
+	}
+	_, ok := r.Meta[MetaServerInfo]
+	return ok
+}
+
+func (r *Report) classify() {
+	modern := r.AnswersDiscover || (r.ServesModernCall && r.ModernResultIsModern)
+
+	switch {
+	case modern && r.AnswersInitialize:
+		r.Era = Dual
+		r.note("Serves both eras, which is the only posture that works with every client.")
+	case modern:
+		r.Era = Modern
+		r.note("Modern only. A legacy client has no fall-forward mechanism and will fail.")
+	case r.AnswersInitialize:
+		r.Era = Legacy
+		r.note("Legacy only. A modern client that skips the server/discover probe is at risk.")
+	default:
+		r.Era = Unknown
+		r.note("Answered neither opening.")
+	}
+
+	if r.ServesModernCall && !r.ModernResultIsModern {
+		r.SilentDowngrade = true
+		r.note("Ran a request declaring protocolVersion " + Version +
+			" and answered in the legacy shape, with no error and no version acknowledgement. " +
+			"A client reading only content cannot tell it was downgraded.")
+	}
+	if !r.AnswersDiscover && r.DiscoverError != "" {
+		r.note("server/discover fails deterministically (" + r.DiscoverError +
+			"), which is the probe the spec tells stdio clients to send first.")
+	}
+}
+
+func (r *Report) note(s string) { r.Notes = append(r.Notes, s) }
+
+// exchange runs one request against a fresh server process and returns the
+// first response, or nil when the server stayed silent.
+func exchange(ctx context.Context, timeout time.Duration, name string, args []string, req map[string]any) (*rpcResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = stdin.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := stdin.Write(append(body, '\n')); err != nil {
+		return nil, nil
+	}
+
+	type result struct {
+		resp *rpcResponse
+		err  error
+	}
+	done := make(chan result, 1)
+	go func() {
+		sc := bufio.NewScanner(stdout)
+		sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)
+		for sc.Scan() {
+			line := strings.TrimSpace(sc.Text())
+			if line == "" || !strings.HasPrefix(line, "{") {
+				continue
+			}
+			var resp rpcResponse
+			if json.Unmarshal([]byte(line), &resp) != nil {
+				continue
+			}
+			if resp.Result == nil && resp.Error == nil {
+				continue // a notification, not our answer
+			}
+			done <- result{resp: &resp}
+			return
+		}
+		done <- result{err: sc.Err()}
+	}()
+
+	select {
+	case r := <-done:
+		if r.err != nil && !errors.Is(r.err, context.DeadlineExceeded) {
+			return nil, r.err
+		}
+		return r.resp, nil
+	case <-ctx.Done():
+		return nil, nil // silence is a finding, not an error
+	}
+}

--- a/internal/mcpera/mcpera.go
+++ b/internal/mcpera/mcpera.go
@@ -139,6 +139,13 @@ func Probe(ctx context.Context, timeout time.Duration, name string, args ...stri
 		rep.DiscoverError = "no response"
 	case disc.Error != nil:
 		rep.DiscoverError = fmt.Sprintf("%d: %s", disc.Error.Code, disc.Error.Message)
+	case !describesAServer(disc.Result):
+		// A reply with no error but nothing in it is not an answer to
+		// server/discover. Counting it as one is how a server that merely
+		// tolerates the method gets published as dual-era, which is the row a
+		// client would trust most. The modern tools/list check below already
+		// requires a result; this is the same bar.
+		rep.DiscoverError = "answered without describing a server"
 	default:
 		rep.AnswersDiscover = true
 	}
@@ -175,6 +182,23 @@ func isModernResult(raw json.RawMessage) bool {
 	}
 	_, ok := r.Meta[MetaServerInfo]
 	return ok
+}
+
+// describesAServer reports whether a server/discover result carries anything.
+//
+// The revision has the method return what a client would otherwise have learned
+// from initialize, so an answer names the server, its capabilities or the
+// versions it speaks. An absent result, a null, or an empty object answers none
+// of that, and a probe cannot call a server dual-era on the strength of it.
+func describesAServer(result json.RawMessage) bool {
+	if len(result) == 0 {
+		return false
+	}
+	var fields map[string]json.RawMessage
+	if json.Unmarshal(result, &fields) != nil {
+		return false
+	}
+	return len(fields) > 0
 }
 
 func (r *Report) classify() {

--- a/internal/mcpera/mcpera_test.go
+++ b/internal/mcpera/mcpera_test.go
@@ -1,0 +1,197 @@
+package mcpera_test
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/meshery-extensions/meshery-mcp-server/internal/mcpera"
+)
+
+// The fake servers run as this test binary re-invoked with an era argument,
+// so the suite stays hermetic and needs no external SDK.
+func helper(era string) (string, []string) {
+	return os.Args[0], []string{"-test.run=TestFakeServer", "--", era}
+}
+
+func probe(t *testing.T, era string) *mcpera.Report {
+	t.Helper()
+	return probeWithin(t, era, 4*time.Second)
+}
+
+func probeWithin(t *testing.T, era string, timeout time.Duration) *mcpera.Report {
+	t.Helper()
+	name, args := helper(era)
+	rep, err := mcpera.Probe(context.Background(), timeout, name, args...)
+	if err != nil {
+		t.Fatalf("probing %s: %v", era, err)
+	}
+	return rep
+}
+
+// TestLegacyServerIsDetected covers a server that answers initialize, refuses
+// server/discover, and runs a modern request anyway while answering in the old
+// shape. That is the era-ambiguous hazard the specification names.
+func TestLegacyServerIsDetected(t *testing.T) {
+	rep := probe(t, "legacy")
+
+	if rep.Era != mcpera.Legacy {
+		t.Errorf("era = %s, want %s", rep.Era, mcpera.Legacy)
+	}
+	if !rep.AnswersInitialize {
+		t.Error("expected the legacy handshake to succeed")
+	}
+	if rep.AnswersDiscover {
+		t.Error("a legacy server should not answer server/discover")
+	}
+	if !rep.SilentDowngrade {
+		t.Fatal("a legacy server that runs a modern request must be reported as a silent downgrade")
+	}
+	if !strings.Contains(strings.Join(rep.Notes, " "), "cannot tell it was downgraded") {
+		t.Errorf("the notes should say what the client cannot see: %v", rep.Notes)
+	}
+}
+
+// TestDualEraServerIsDetected covers the posture that works with every client.
+func TestDualEraServerIsDetected(t *testing.T) {
+	rep := probe(t, "dual")
+
+	if rep.Era != mcpera.Dual {
+		t.Errorf("era = %s, want %s", rep.Era, mcpera.Dual)
+	}
+	if rep.SilentDowngrade {
+		t.Error("a modern-shaped result is not a downgrade")
+	}
+}
+
+// TestModernOnlyServerIsDetected covers a server that refuses initialize. A
+// legacy client has no fall-forward mechanism, so this is a real posture rather
+// than a broken one.
+func TestModernOnlyServerIsDetected(t *testing.T) {
+	rep := probe(t, "modern")
+
+	if rep.Era != mcpera.Modern {
+		t.Errorf("era = %s, want %s", rep.Era, mcpera.Modern)
+	}
+	if rep.AnswersInitialize {
+		t.Error("a modern-only server should refuse initialize")
+	}
+}
+
+// TestSilenceIsAFindingNotAnError covers a server that never answers. The spec
+// lists staying silent as one of the three ways a modern-to-legacy exchange
+// fails, so the probe has to survive it.
+func TestSilenceIsAFindingNotAnError(t *testing.T) {
+	// A short timeout here: the point is that silence is survived, and three
+	// probes at the default would dominate the suite's runtime.
+	rep := probeWithin(t, "silent", 300*time.Millisecond)
+
+	if rep.Era != mcpera.Unknown {
+		t.Errorf("era = %s, want %s", rep.Era, mcpera.Unknown)
+	}
+	if rep.SilentDowngrade {
+		t.Error("silence is not a downgrade")
+	}
+}
+
+// TestModernResultMarkersAreWhatDistinguish pins the detection itself. A result
+// carrying resultType, or serverInfo in _meta, is modern; the bare legacy body
+// is not, and that difference is the only thing on the wire that separates a
+// downgraded exchange from a real one.
+func TestModernResultMarkersAreWhatDistinguish(t *testing.T) {
+	withMarkers := probe(t, "dual")
+	if !withMarkers.ModernResultIsModern {
+		t.Error("a result carrying resultType should read as modern")
+	}
+	without := probe(t, "legacy")
+	if without.ModernResultIsModern {
+		t.Error("a bare legacy body should not read as modern")
+	}
+	if !without.ServesModernCall {
+		t.Error("the legacy fake did serve the request, which is the point")
+	}
+}
+
+// TestFakeServer is the fake server. It is a normal test when run without the
+// era argument and a JSON-RPC server over stdio when given one.
+func TestFakeServer(t *testing.T) {
+	era := ""
+	for i, a := range os.Args {
+		if a == "--" && i+1 < len(os.Args) {
+			era = os.Args[i+1]
+		}
+	}
+	if era == "" {
+		t.Skip("not running as a fake server")
+	}
+	serve(era)
+	os.Exit(0)
+}
+
+func serve(era string) {
+	out := bufio.NewWriter(os.Stdout)
+	defer out.Flush()
+	sc := bufio.NewScanner(os.Stdin)
+	for sc.Scan() {
+		var req struct {
+			ID     any    `json:"id"`
+			Method string `json:"method"`
+		}
+		if json.Unmarshal(sc.Bytes(), &req) != nil {
+			continue
+		}
+		if era == "silent" {
+			continue
+		}
+		resp := respond(era, req.Method, req.ID)
+		if resp == nil {
+			continue
+		}
+		b, _ := json.Marshal(resp)
+		out.Write(append(b, '\n'))
+		out.Flush()
+	}
+}
+
+func respond(era, method string, id any) map[string]any {
+	ok := func(result any) map[string]any {
+		return map[string]any{"jsonrpc": "2.0", "id": id, "result": result}
+	}
+	fail := func(code int, msg string) map[string]any {
+		return map[string]any{"jsonrpc": "2.0", "id": id,
+			"error": map[string]any{"code": code, "message": msg}}
+	}
+	legacyResult := map[string]any{"tools": []any{}}
+	modernResult := map[string]any{
+		"tools": []any{}, "resultType": "complete",
+		"_meta": map[string]any{mcpera.MetaServerInfo: map[string]any{"name": "fake"}},
+	}
+
+	switch method {
+	case "initialize":
+		if era == "modern" {
+			return fail(-32601, "method not found: initialize")
+		}
+		return ok(map[string]any{
+			"protocolVersion": "2025-11-25",
+			"capabilities":    map[string]any{},
+			"serverInfo":      map[string]any{"name": "fake", "version": "0"},
+		})
+	case "server/discover":
+		if era == "legacy" {
+			return fail(-32601, "Method server/discover not found")
+		}
+		return ok(modernResult)
+	case "tools/list":
+		if era == "legacy" {
+			// The hazard: it runs the modern request and answers in the old shape.
+			return ok(legacyResult)
+		}
+		return ok(modernResult)
+	}
+	return nil
+}

--- a/internal/mcpera/verdict_test.go
+++ b/internal/mcpera/verdict_test.go
@@ -159,3 +159,32 @@ func TestExecutedMismatchStillReported(t *testing.T) {
 		t.Error("a server that ran the body while the header disagreed must still be reported")
 	}
 }
+
+// TestOversizedBodyIsNotBlamedOnTheServer covers this probe's own limit. A
+// response larger than it reads arrives cut in half, parses as nothing, and
+// would otherwise be reported as a server that answered something other than
+// JSON-RPC. The call was served; only the shape is unknown.
+func TestOversizedBodyIsNotBlamedOnTheServer(t *testing.T) {
+	// One valid JSON-RPC result, padded past the read limit.
+	huge := `{"jsonrpc":"2.0","id":1,"result":{"resultType":"complete","pad":"` +
+		strings.Repeat("x", 9<<20) + `"}}`
+	rep := probeHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, huge)
+	})
+	if !rep.BodyTruncated {
+		t.Error("a body past the read limit should be reported as truncated")
+	}
+	if !rep.ServesModern {
+		t.Error("the call was served, the size of the answer does not change that")
+	}
+	if rep.RefusedModern != "" {
+		t.Errorf("a large answer is not a refusal, got %q", rep.RefusedModern)
+	}
+	if rep.ExecutedMismatched {
+		t.Error("whether the tool ran is unknown when the body could not be read")
+	}
+	if !strings.Contains(strings.Join(rep.Notes, " "), "larger than") {
+		t.Errorf("the notes should name the limit: %v", rep.Notes)
+	}
+}

--- a/internal/mcpera/verdict_test.go
+++ b/internal/mcpera/verdict_test.go
@@ -2,6 +2,7 @@ package mcpera_test
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -186,5 +187,77 @@ func TestOversizedBodyIsNotBlamedOnTheServer(t *testing.T) {
 	}
 	if !strings.Contains(strings.Join(rep.Notes, " "), "larger than") {
 		t.Errorf("the notes should name the limit: %v", rep.Notes)
+	}
+}
+
+// TestMcpNameIsEncodedWhenItHasTo covers this probe's own conformance. Revision
+// 2026-07-28 says a client MUST carry a header value outside the safe ASCII set
+// in a Base64 sentinel, so a probe that sent it raw would be measuring servers
+// against a request the spec does not permit.
+func TestMcpNameIsEncodedWhenItHasTo(t *testing.T) {
+	for _, tc := range []struct {
+		name, tool, want string
+	}{
+		{"plain name travels as-is", "get_weather", "get_weather"},
+		{"non-ascii is encoded", "café", "=?base64?" + base64.StdEncoding.EncodeToString([]byte("café")) + "?="},
+		{"trailing space is encoded", "tool ", "=?base64?" + base64.StdEncoding.EncodeToString([]byte("tool ")) + "?="},
+		{"newline is encoded", "a\nb", "=?base64?" + base64.StdEncoding.EncodeToString([]byte("a\nb")) + "?="},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got == "" {
+					got = r.Header.Get("Mcp-Name")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`))
+			}))
+			defer srv.Close()
+			if _, err := mcpera.ProbeHTTP(context.Background(), 3*time.Second, srv.URL, tc.tool, "other", nil); err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Errorf("Mcp-Name = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHeaderMismatchNeedsTheStatusToo separates full conformance from a server
+// that caught the mismatch but answered with the wrong status. The revision
+// requires 400 and -32020 together, and a client keying on the status alone
+// would read a 200 carrying -32020 as a success.
+func TestHeaderMismatchNeedsTheStatusToo(t *testing.T) {
+	reject := func(code int) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+			var req struct {
+				Params struct {
+					Name string `json:"name"`
+				} `json:"params"`
+			}
+			_ = json.Unmarshal(body, &req)
+			w.Header().Set("Content-Type", "application/json")
+			if r.Header.Get("Mcp-Name") != req.Params.Name {
+				w.WriteHeader(code)
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32020,"message":"header mismatch"}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`))
+		}
+	}
+
+	if rep := probeHandler(t, reject(http.StatusBadRequest)); !rep.ValidatesHeaderBody {
+		t.Errorf("400 with -32020 is what the revision asks for: %v", rep.Notes)
+	}
+	rep := probeHandler(t, reject(http.StatusOK))
+	if rep.ValidatesHeaderBody {
+		t.Error("-32020 under a 200 is not the rejection the revision specifies")
+	}
+	if rep.ExecutedMismatched {
+		t.Error("the server did catch it, so nothing executed")
+	}
+	if !strings.Contains(strings.Join(rep.Notes, " "), "rather than the 400") {
+		t.Errorf("the note should name the missing status: %v", rep.Notes)
 	}
 }

--- a/internal/mcpera/verdict_test.go
+++ b/internal/mcpera/verdict_test.go
@@ -261,3 +261,36 @@ func TestHeaderMismatchNeedsTheStatusToo(t *testing.T) {
 		t.Errorf("the note should name the missing status: %v", rep.Notes)
 	}
 }
+
+// TestHeaderEncodingMatchesTheSpecExamples checks the encoder against the
+// normative table in the transport spec rather than against my reading of it.
+// The last row is the one that is easy to miss: a plain-ASCII value already
+// wearing the sentinel markers has to be encoded too, or a server decodes it
+// into something the body never said.
+func TestHeaderEncodingMatchesTheSpecExamples(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"us-west1", "us-west1"},
+		{"Hello, 世界", "=?base64?SGVsbG8sIOS4lueVjA==?="},
+		{" padded ", "=?base64?IHBhZGRlZCA=?="},
+		{"line1\nline2", "=?base64?bGluZTEKbGluZTI=?="},
+		{"=?base64?literal?=", "=?base64?PT9iYXNlNjQ/bGl0ZXJhbD89?="},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			var got string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got == "" {
+					got = r.Header.Get("Mcp-Name")
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`))
+			}))
+			defer srv.Close()
+			if _, err := mcpera.ProbeHTTP(context.Background(), 3*time.Second, srv.URL, tc.in, "other", nil); err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Errorf("Mcp-Name = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/mcpera/verdict_test.go
+++ b/internal/mcpera/verdict_test.go
@@ -1,0 +1,161 @@
+package mcpera_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/meshery-extensions/meshery-mcp-server/internal/mcpera"
+)
+
+// probe runs a probe against a handler and fails the test if it errors.
+func probeHandler(t *testing.T, h http.HandlerFunc) *mcpera.HTTPReport {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	rep, err := mcpera.ProbeHTTP(context.Background(), 3*time.Second, srv.URL, "alpha", "beta", nil)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	return rep
+}
+
+// TestNonJSONBodyIsNotAnExecution covers the hazard row of the published table.
+// An endpoint fronted by a single-page app or a proxy answers 200 with HTML to
+// anything, including a call whose header disagrees with its body. Nothing about
+// that says a tool ran, and reporting it as one would put a server that is not
+// an MCP server at all in the row reserved for the worst finding.
+func TestNonJSONBodyIsNotAnExecution(t *testing.T) {
+	rep := probeHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<!doctype html><html><body>app shell</body></html>"))
+	})
+	if rep.ExecutedMismatched {
+		t.Error("an unreadable body was reported as the mismatched tool having executed")
+	}
+	if rep.ServesModern {
+		t.Error("an endpoint answering HTML was reported as serving the modern era")
+	}
+	if !strings.Contains(strings.Join(rep.Notes, " "), "not JSON-RPC") {
+		t.Errorf("the report should say the body was not JSON-RPC: %v", rep.Notes)
+	}
+}
+
+// TestErrorUnder200IsARefusal is the disagreeing fixture for the two things a
+// verdict is built from: the status line and the body. JSON-RPC carries its
+// errors in the body, so a server refusing the modern version answers 200 with
+// an error object. Reading only the status would publish that refusal as
+// service, in the silent-downgrade row.
+func TestErrorUnder200IsARefusal(t *testing.T) {
+	rep := probeHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"unsupported protocol version"}}`))
+	})
+	if rep.ServesModern {
+		t.Error("a JSON-RPC refusal under a 200 was reported as serving the modern era")
+	}
+	if rep.RefusedModern == "" {
+		t.Error("the refusal should be recorded")
+	}
+	if !strings.Contains(rep.RefusedModern, "-32600") {
+		t.Errorf("the refusal should name the error code, got %q", rep.RefusedModern)
+	}
+	if rep.ExecutedMismatched {
+		t.Error("a server that refused both calls cannot have executed the mismatched one")
+	}
+}
+
+// TestRedirectIsNotFollowed pins that a 3xx is reported rather than chased. Go
+// rewrites a redirected POST into a GET against the new location, so a followed
+// redirect describes neither the request that was sent nor the endpoint that was
+// asked about.
+func TestRedirectIsNotFollowed(t *testing.T) {
+	var landed bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/elsewhere", func(w http.ResponseWriter, r *http.Request) {
+		landed = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[]}}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/elsewhere", http.StatusFound)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	rep, err := mcpera.ProbeHTTP(context.Background(), 3*time.Second, srv.URL, "alpha", "beta", nil)
+	if err != nil {
+		t.Fatalf("probe: %v", err)
+	}
+	if landed {
+		t.Error("the probe followed a redirect, so it measured a different endpoint than the one named")
+	}
+	if rep.ServesModern {
+		t.Error("a redirect is not an answer about protocol eras")
+	}
+	if rep.ExecutedMismatched {
+		t.Error("a redirected call did not execute anything")
+	}
+}
+
+// TestNonJSONOnTheMismatchAloneIsNotAnExecution isolates the mismatch guard.
+//
+// The server above answers HTML to everything, so the agreeing call already
+// fails and the verdict never reaches the question of what the mismatched call
+// did. Here the agreeing call is served properly and only the disagreeing one
+// is intercepted, which is what a proxy or a filter in front of a real MCP
+// server looks like. The header was never judged, so nothing is known about
+// whether the tool ran.
+func TestNonJSONOnTheMismatchAloneIsNotAnExecution(t *testing.T) {
+	rep := probeHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		var req struct {
+			Params struct {
+				Name string `json:"name"`
+			} `json:"params"`
+		}
+		_ = json.Unmarshal(body, &req)
+		if r.Header.Get("Mcp-Name") != req.Params.Name {
+			// Intercepted before it reached the server.
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, _ = w.Write([]byte("<!doctype html><html><body>request blocked</body></html>"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ok"}]}}`))
+	})
+	if !rep.ServesModern {
+		t.Fatal("the agreeing call was served, so the probe should say so")
+	}
+	if rep.ExecutedMismatched {
+		t.Error("a body that is not JSON-RPC says nothing about whether the tool ran")
+	}
+	if !strings.Contains(strings.Join(rep.Notes, " "), "not JSON-RPC") {
+		t.Errorf("the report should say the body was unreadable: %v", rep.Notes)
+	}
+}
+
+// TestExecutedMismatchStillReported is the positive control for the three tests
+// above. A server that genuinely ignores the header and runs the body must
+// still land in the hazard row, otherwise the guards have simply turned the
+// finding off.
+func TestExecutedMismatchStillReported(t *testing.T) {
+	rep := probeHandler(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// The header is ignored and the body is run, which is what a server
+		// predating the rule does.
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ran"}]}}`))
+	})
+	if !rep.ServesModern {
+		t.Fatal("this server does serve the agreeing call")
+	}
+	if !rep.ExecutedMismatched {
+		t.Error("a server that ran the body while the header disagreed must still be reported")
+	}
+}


### PR DESCRIPTION
**Notes for Reviewers**

- Relates to #42, which is still open on which protocol revision we target.

I posted measurements on #42 rather than more argument. This is the tool that produced them, so the decision can be re-checked rather than taken on trust, and so whatever we pick cannot quietly regress later.

**What it does**

Probes a server and reports which protocol era it actually serves:

```
$ mcpera ./server
era: legacy

  initialize          yes  (2025-11-25)
  server/discover     no  (-32601: Method server/discover not found)
  modern request      yes
  modern result shape no

  Ran a request declaring protocolVersion 2026-07-28 and answered in the legacy
  shape, with no error and no version acknowledgement. A client reading only
  content cannot tell it was downgraded.
```

Measured against a one-tool stdio server built on each SDK:

| server | `initialize` | `server/discover` | modern request | result shape | era |
|---|---|---|---|---|---|
| mcp-go v0.57.0 | yes | `-32601` | runs it | legacy | legacy |
| mcp-go v0.58.0 | yes | `-32601` | runs it | legacy | legacy |
| mcp-go v1.0.0-beta.1 | yes | yes | runs it | modern | dual-era |
| go-sdk v1.7.0 | yes | yes | runs it | modern | dual-era |

v0.57.0 is the version the tool PRs pin. The distinguishing signal is `resultType` and `serverInfo` in the result `_meta`; a client that reads `content` and stops will not see it.

There is also an HTTP probe for the header validation rule, which the spec added with a stated security reason: an intermediary may route on `Mcp-Name` while the server executes the name in the body. Sending a header naming one tool and a body naming another, go-sdk v1.7.0 (with `Stateless: true`) and mcp-go v1.0.0-beta.1 both reject it with `400` and `-32020`. v0.57.0 with a legacy session runs the tool the body named. That is not v0.57.0 breaking its own revision, since the rule is newer, but it is the divergence the spec's intermediary note warns about.

**Why it is worth having in the repo**

`mcpera` exits non-zero on a silent downgrade, so once #28 lands and Go CI actually runs here, one line in the workflow keeps the server from drifting into the legacy era without anyone noticing. It is the kind of thing that only pays for itself if it is in the tree before the mistake, not after.

It says nothing about which SDK to choose. It reports what a server does.

**No `go.mod`, deliberately**

Same reasoning as #50. Several open PRs each add one and I do not want to be another. These files are stdlib-only, so they compile wherever the scaffolding lands:

```
printf 'module github.com/meshery-extensions/meshery-mcp-server\n\ngo 1.23\n' > go.mod
go test ./internal/mcpera/ -race -cover
```

That is how I verified it, on Go 1.23:

```
ok  github.com/meshery-extensions/meshery-mcp-server/internal/mcpera  2.761s  coverage: 85.5% of statements
```

Say the word if you would rather I push a `go.mod` so CI can run it.

**Testing**

The fake servers are this test binary re-invoked with an era argument, so the suite is hermetic and needs no SDK to run. Covered: a legacy server that silently downgrades, a dual-era one, a modern-only one, a server that stays silent, and the result-marker comparison that separates the first from the second. The HTTP side uses `httptest` fakes for a conformant server, one that ignores the header, SSE framing on both, and a stateful endpoint refusing a stateless call.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a diagnostic command-line tool that identifies whether an MCP server supports legacy, modern, both, or unknown protocol eras.
  - Detects silent compatibility downgrades when modern requests receive legacy responses.
  - Added HTTP checks for protocol support, header/body mismatches, rejected requests, redirects, SSE responses, and oversized responses.
  - Reports probe results, refusals, unanswered requests, discovery details, and troubleshooting notes for CI checks.

- **Documentation**
  - Added guidance on protocol-era behavior, classifications, HTTP probing, and CI usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->