### PR TITLE
[Docs] add a way to run a real Meshery Server for testing

### DIFF
--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -11,9 +11,15 @@ Building the server from source works, and takes about two minutes.
 ./scripts/meshery-dev-server.sh
 ```
 
-It clones `meshery/meshery` into `.meshery-src`, builds `server/cmd`, and serves
-on port 9081 with the built-in `Local` provider. Pass a path to use a checkout
-you already have.
+It fetches `meshery/meshery` at a pinned revision into `.meshery-src`, builds
+`server/cmd`, and serves on port 9081 with the built-in `Local` provider. Pass a
+path to use a checkout you already have.
+
+The pin is `e6ed2de164b42d805b78dd1cdb3c4b415e8686eb`, the revision every
+observation below was made against. Seed counts and endpoint behaviour are
+specific to it. Set `MESHERY_REF` to test a newer Meshery, and treat any
+difference from what is recorded here as a finding about Meshery rather than
+about the tests.
 
 Two things to be accurate about. Setup needs network access, for the clone and
 for a large Go module tree; it is only the running server that needs no remote

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -12,9 +12,18 @@ Building the server from source works, and takes about two minutes.
 ```
 
 It clones `meshery/meshery` into `.meshery-src`, builds `server/cmd`, and serves
-on `http://127.0.0.1:9081` with the built-in `Local` provider, so no remote
-provider, credentials or network access are needed. Pass a path to use a checkout
+on port 9081 with the built-in `Local` provider. Pass a path to use a checkout
 you already have.
+
+Two things to be accurate about. Setup needs network access, for the clone and
+for a large Go module tree; it is only the running server that needs no remote
+provider and no credentials, because `PROVIDER=Local` selects the built-in one.
+
+And it listens on every interface rather than loopback. Meshery offers no
+bind-address option: `server/router/server.go` passes `fmt.Sprintf(":%d", port)`
+straight to `http.ListenAndServe`. So this is a development server, and running
+it on an untrusted network exposes it. Firewall the port or stay on a trusted
+one.
 
 It seeds itself with roughly 355 designs and 292 models, which is enough to
 exercise pagination and the design endpoints against real volume rather than a

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,0 +1,83 @@
+# Testing against a real Meshery Server
+
+Everything in this repository is currently tested against mocks. That is not
+anyone's preference, it is a consequence: Meshery publishes an amd64-only image,
+and under emulation on arm64 it crashes during content seeding, so a lot of
+contributors simply cannot get one running.
+
+Building the server from source works, and takes about two minutes.
+
+```bash
+./scripts/meshery-dev-server.sh
+```
+
+It clones `meshery/meshery` into `.meshery-src`, builds `server/cmd`, and serves
+on `http://127.0.0.1:9081` with the built-in `Local` provider, so no remote
+provider, credentials or network access are needed. Pass a path to use a checkout
+you already have.
+
+It seeds itself with roughly 355 designs and 292 models, which is enough to
+exercise pagination and the design endpoints against real volume rather than a
+two-row fixture.
+
+## Why it is worth the two minutes
+
+A mock can only be as correct as its author's reading of the API, and it returns
+the shape the code under test expects. That is comfortable and it hides a
+specific class of mistake. Some of what a live server says that a mock will not:
+
+**The design file is served in two different encodings.** `GET /api/pattern`
+returns `patternFile` as YAML; `GET /api/pattern/{id}` returns the same field as
+JSON. Six designs checked, all six the same way. `SaveMesheryPattern` stores the
+design with `yaml.Marshal` and the list path returns that stored form verbatim. A
+client that decodes the list form as JSON fails on every design and passes
+against any mock, because nobody writes a mock that serves one field two ways.
+
+**Paging is zero-based, and both halves of it vary per endpoint.** Asking each
+endpoint with `pagesize`, with `pageSize`, and with neither:
+
+| endpoint | reads `pageSize` | default |
+|---|---|---|
+| `/api/pattern` | no | 10 |
+| `/api/system/kubernetes/contexts` | no | 10 |
+| `/api/identity/orgs` | no | 10 |
+| `/api/integrations/connections` | yes | 10 |
+| `/api/system/meshsync/resources` | yes | 25 |
+| `/api/registry/models` | yes | 25 |
+
+The two columns are independent, so one cannot be inferred from the other, and a
+client assuming a single default mis-pages against four of these six.
+
+**Wrong requests answer `200` with nothing.** `GET /api/system/meshsync/resources`
+without `clusterIds` binds an empty slice into `cluster_id IN (?)`, matches no
+rows, and returns success. With a malformed `clusterIds` it is a `400`. The two
+failures look nothing alike and only one of them is loud.
+
+**Authentication answers before the session check.** With no provider selected,
+an unauthenticated `GET`, `POST` and `DELETE` all come back `302` to
+`/provider?ref=<base64 path>`, before any session logic runs. `Local` is the
+canonical local provider name and `None` is still accepted as the legacy alias.
+
+## Writing tests against it
+
+Put them behind a build tag so the default suite stays hermetic and needs no
+server:
+
+```go
+//go:build integration
+```
+
+```bash
+MESHERY_URL=http://127.0.0.1:9081 go test -tags integration ./...
+```
+
+Skip rather than fail when the variable is unset, so `go test ./...` is still the
+command a contributor runs without setup.
+
+## What this does not give you
+
+A Kubernetes cluster. MeshSync needs an operator running in-cluster, so without
+one the cluster-scoped endpoints can be exercised against their guards and their
+empty shapes but not against discovered workloads. That is worth knowing before
+writing a test that expects resources back: an empty result there is the correct
+answer, not a failure.

--- a/scripts/meshery-dev-server.sh
+++ b/scripts/meshery-dev-server.sh
@@ -10,8 +10,15 @@
 #   ./scripts/meshery-dev-server.sh                 # clones into ./.meshery-src
 #   ./scripts/meshery-dev-server.sh /path/to/meshery
 #
-# Serves on $PORT (default 9081) with the built-in Local provider, so no remote
-# provider, credentials or network are needed.
+# Setup needs network: it clones meshery/meshery when the checkout is absent,
+# and the build downloads a large module tree. Once built, running it needs no
+# remote provider and no credentials, because PROVIDER=Local selects the
+# built-in provider.
+#
+# It listens on every interface, not loopback. Meshery has no bind-address
+# option: server/router/server.go passes fmt.Sprintf(":%d", port) straight to
+# http.ListenAndServe. Treat it as a development server and do not run it on a
+# network you do not trust.
 set -euo pipefail
 
 PORT="${PORT:-9081}"
@@ -31,7 +38,8 @@ BIN="$(cd "$SRC" && pwd)/meshery-server"
 echo "building the server (first build pulls a large dependency tree)"
 (cd "$SRC/server/cmd" && go build -o "$BIN" .)
 
-echo "serving on http://127.0.0.1:$PORT with the Local provider"
+echo "serving on port $PORT with the Local provider"
+echo "note: Meshery binds every interface, it has no loopback option; dev use only"
 cd "$SRC/server/cmd"
 PORT="$PORT" \
 PROVIDER=Local \

--- a/scripts/meshery-dev-server.sh
+++ b/scripts/meshery-dev-server.sh
@@ -24,9 +24,18 @@ set -euo pipefail
 PORT="${PORT:-9081}"
 SRC="${1:-.meshery-src}"
 
+# The revision every observation in docs/INTEGRATION.md was made against.
+# Override with MESHERY_REF to test a newer Meshery, knowing the seed counts
+# and endpoint behaviour recorded there may then differ.
+MESHERY_REF="${MESHERY_REF:-e6ed2de164b42d805b78dd1cdb3c4b415e8686eb}"
+
 if [ ! -d "$SRC" ]; then
-  echo "cloning meshery/meshery into $SRC"
-  git clone --depth 1 https://github.com/meshery/meshery.git "$SRC"
+  echo "fetching meshery/meshery at $MESHERY_REF into $SRC"
+  mkdir -p "$SRC"
+  git -C "$SRC" init -q
+  git -C "$SRC" remote add origin https://github.com/meshery/meshery.git
+  git -C "$SRC" fetch -q --depth 1 origin "$MESHERY_REF"
+  git -C "$SRC" checkout -q FETCH_HEAD
 fi
 
 if ! command -v go >/dev/null 2>&1; then

--- a/scripts/meshery-dev-server.sh
+++ b/scripts/meshery-dev-server.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Builds and runs a Meshery Server from source, for testing an MCP server
+# against something real.
+#
+# The published image is amd64 only and crashes under emulation on arm64 during
+# content seeding, which is why so much of this work gets tested against mocks.
+# The source builds and runs natively.
+#
+#   ./scripts/meshery-dev-server.sh                 # clones into ./.meshery-src
+#   ./scripts/meshery-dev-server.sh /path/to/meshery
+#
+# Serves on $PORT (default 9081) with the built-in Local provider, so no remote
+# provider, credentials or network are needed.
+set -euo pipefail
+
+PORT="${PORT:-9081}"
+SRC="${1:-.meshery-src}"
+
+if [ ! -d "$SRC" ]; then
+  echo "cloning meshery/meshery into $SRC"
+  git clone --depth 1 https://github.com/meshery/meshery.git "$SRC"
+fi
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "go is required; meshery/meshery targets the version in its go.mod" >&2
+  exit 1
+fi
+
+BIN="$(cd "$SRC" && pwd)/meshery-server"
+echo "building the server (first build pulls a large dependency tree)"
+(cd "$SRC/server/cmd" && go build -o "$BIN" .)
+
+echo "serving on http://127.0.0.1:$PORT with the Local provider"
+cd "$SRC/server/cmd"
+PORT="$PORT" \
+PROVIDER=Local \
+USE_GO_POLICY_ENGINE=true \
+LOG_LEVEL="${LOG_LEVEL:-3}" \
+APP_PATH=./apps.json \
+KEYS_PATH=../../server/permissions/keys.csv \
+MESHSYNC_DEFAULT_DEPLOYMENT_MODE=operator \
+exec "$BIN"


### PR DESCRIPTION
**Notes for Reviewers**

- Relates to #16, the Integration Tests section specifically.

#16 asks for tests against "a real (or Docker-compose-based) Meshery instance". The obstacle is upstream of the tests: Meshery publishes an amd64-only image, and under emulation on arm64 it crashes during content seeding. That is a good part of why everything in flight here is tested against mocks.

Building the server from source works and takes about two minutes. `scripts/meshery-dev-server.sh` clones `meshery/meshery`, builds `server/cmd`, and serves on port 9081 with the built-in `Local` provider. Setup needs network access for the clone and the Go module tree; the running server needs no remote provider and no credentials. It listens on every interface, since Meshery has no bind-address option (`server/router/server.go` passes `fmt.Sprintf(":%d", port)` straight to `http.ListenAndServe`), so treat it as a development server and firewall the port:

```
./scripts/meshery-dev-server.sh
```

It seeds itself with roughly 355 designs and 292 models, which is enough to exercise pagination against real volume rather than a two-row fixture.

**Why this is worth having before the tools land, not after**

`docs/INTEGRATION.md` records what a live server says that a mock does not. All of it measured against a server built this way, not read out of the source:

- **`patternFile` comes back in two different encodings.** `GET /api/pattern` serves it as YAML, `GET /api/pattern/{id}` serves the same field as JSON. Six designs checked, all six the same way. `SaveMesheryPattern` stores the design with `yaml.Marshal` and the list path returns that stored form verbatim. A client decoding the list form as JSON fails on every design and passes against any mock, because nobody writes a mock that serves one field two ways.
- **Both halves of paging vary per endpoint, and they are independent.** `/api/pattern`, contexts and orgs read only lowercase `pagesize` and default to 10; connections reads `pageSize` and still defaults to 10; meshsync resources and registry read `pageSize` and default to 25. A client assuming one default mis-pages against four of six.
- **A missing cluster filter is `200` with nothing; a malformed one is `400`.** Two failures that look nothing alike, and only one is loud.
- **The provider gate answers before the session check.** With no provider selected, an unauthenticated GET, POST and DELETE all return `302` to `/provider?ref=<base64 path>`. `Local` is the canonical provider name, `None` still works as the legacy alias.

I found the first of those by asking a live server for the same design twice. I would not have found it any other way, and it would have shipped.

**Scope**

Docs and one script. No `Makefile`, because #28 adds one and I did not want to collide with it; the script stands alone and a target can wrap it later. No test files, since the tools they would exercise are still in flight. The guide suggests `//go:build integration` with a skip when `MESHERY_URL` is unset, so `go test ./...` stays the command a contributor runs with no setup.

What this does not provide is a Kubernetes cluster. MeshSync wants an operator in-cluster, so the cluster-scoped endpoints can be exercised against their guards and empty shapes but not against discovered workloads. Worth knowing before writing a test that expects resources back: an empty result there is the correct answer.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running integration tests against a locally built Meshery server.
  * Documented live-server response formats, pagination, authentication redirects, and cluster-scoped endpoint limitations.

* **New Features**
  * Added a script to fetch, build, and run a local Meshery server for integration testing.
  * Supports configurable source location and port settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
